### PR TITLE
Travis-CI: Install linux-headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     sources:
       - sourceline: 'ppa:masterminds/glide'
     packages:
+      - linux-headers-generic
       - libarchive-dev
       - glide
 


### PR DESCRIPTION
We need to use the mtd Linux API, so we can inquiry the flash type, so
for the tests, it must be available.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>