### PR TITLE
Fixes intermittent broken pipe error

### DIFF
--- a/utils/copy_test.go
+++ b/utils/copy_test.go
@@ -1148,7 +1148,8 @@ func TestCopyToProcessStdinWithProcessExitError(t *testing.T) {
 	defer os.RemoveAll(testPath)
 
 	binaryContent := `#!/bin/sh
-echo "stdout string $@"
+read stuff
+echo "stdout string $stuff"
 exit 1
 `
 	fakeCmdPath := path.Join(testPath, "binary")


### PR DESCRIPTION
The binary being executed didn't expect anything on stdin, so
sometimes its execution was finished before we even write something on
that stdin, leading to a write in a broken pipe.

Now the binary do a "read" command to force the use of stdin, as it is
expected to do so.

Fixes #12.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>