### PR TITLE
Create new package for each mock

### DIFF
--- a/activeinactive/activeinactive_test.go
+++ b/activeinactive/activeinactive_test.go
@@ -12,12 +12,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/UpdateHub/updatehub/testsmocks"
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultImplActive(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", "updatehub-active-get").Return([]byte("1"), nil)
 
 	di := DefaultImpl{
@@ -33,7 +33,7 @@ func TestDefaultImplActive(t *testing.T) {
 }
 
 func TestDefaultImplActiveWithExecuteError(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", "updatehub-active-get").Return([]byte(""), fmt.Errorf("execute error"))
 
 	di := DefaultImpl{
@@ -49,7 +49,7 @@ func TestDefaultImplActiveWithExecuteError(t *testing.T) {
 }
 
 func TestDefaultImplActiveWithParseIntError(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", "updatehub-active-get").Return([]byte("a"), nil)
 
 	di := DefaultImpl{
@@ -65,7 +65,7 @@ func TestDefaultImplActiveWithParseIntError(t *testing.T) {
 }
 
 func TestDefaultImplSetActive(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", "updatehub-active-set 1").Return([]byte(""), nil)
 
 	di := DefaultImpl{
@@ -79,7 +79,7 @@ func TestDefaultImplSetActive(t *testing.T) {
 }
 
 func TestDefaultImplSetActiveWithExecuteError(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", "updatehub-active-set 1").Return([]byte(""), fmt.Errorf("execute error"))
 
 	di := DefaultImpl{

--- a/installmodes/imxkobs/imxkobs_test.go
+++ b/installmodes/imxkobs/imxkobs_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/UpdateHub/updatehub/installmodes"
-	"github.com/UpdateHub/updatehub/testsmocks"
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 	"github.com/UpdateHub/updatehub/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -154,7 +154,7 @@ func TestImxKobsInstallSuccessCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			clm := &testsmocks.CmdLineExecuterMock{}
+			clm := &cmdlinemock.CmdLineExecuterMock{}
 			clm.On("Execute", tc.ExpectedCmdLineExecuter).Return([]byte("combinedOutput"), nil)
 
 			ik := ImxKobsObject{CmdLineExecuter: clm}
@@ -175,7 +175,7 @@ func TestImxKobsInstallSuccessCases(t *testing.T) {
 }
 
 func TestImxKobsInstallFailure(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	expectedCmdline := "kobs-ng init -x a562ce06ed7398848eb910bb60c8c6f68ff36c33701afc30705a96d8eab12123 --search_exponent=1 --chip_0_device_path=/dev/mtd0 --chip_1_device_path=/dev/mtd1 -v"
 	combinedOutput := "combinedOutput"
 	clm.On("Execute", expectedCmdline).Return([]byte(combinedOutput), fmt.Errorf("Error executing 'kobs-ng'. Output: "+combinedOutput))

--- a/installmodes/raw/raw_test.go
+++ b/installmodes/raw/raw_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
-	"github.com/UpdateHub/updatehub/testsmocks"
+	"github.com/UpdateHub/updatehub/testsmocks/copymock"
+	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
+	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
 	"github.com/UpdateHub/updatehub/utils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -60,15 +62,15 @@ func TestRawSetupWithNotSupportedTargetTypes(t *testing.T) {
 }
 
 func TestRawInstallWithCopyFileError(t *testing.T) {
-	fsbm := &testsmocks.FileSystemBackendMock{}
+	fsbm := &filesystemmock.FileSystemBackendMock{}
 
-	lam := &testsmocks.LibArchiveMock{}
+	lam := &libarchivemock.LibArchiveMock{}
 
 	targetDevice := "/dev/xx1"
 	sha256sum := "5bdbf286cb4adcff26befa2183f3167c053bc565036736eaa2ae429fe910d93c"
 	compressed := false
 
-	cm := &testsmocks.CopierMock{}
+	cm := &copymock.CopierMock{}
 	cm.On("CopyFile", fsbm, lam, sha256sum, targetDevice, 128*1024, 0, 0, -1, true, compressed).Return(fmt.Errorf("copy file error"))
 
 	r := RawObject{
@@ -122,11 +124,11 @@ func TestRawInstallWithSuccess(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			fsbm := &testsmocks.FileSystemBackendMock{}
+			fsbm := &filesystemmock.FileSystemBackendMock{}
 
-			lam := &testsmocks.LibArchiveMock{}
+			lam := &libarchivemock.LibArchiveMock{}
 
-			cm := &testsmocks.CopierMock{}
+			cm := &copymock.CopierMock{}
 			cm.On("CopyFile", fsbm, lam, tc.Sha256sum, tc.Target, tc.ExpectedChunkSize, tc.Skip, tc.Seek, tc.Count, tc.Truncate, tc.Compressed).Return(nil)
 
 			r := RawObject{Copier: cm, FileSystemBackend: fsbm, LibArchiveBackend: lam}

--- a/installmodes/ubifs/ubifs_test.go
+++ b/installmodes/ubifs/ubifs_test.go
@@ -8,7 +8,11 @@ import (
 
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/installmodes/internal/testsutils"
-	"github.com/UpdateHub/updatehub/testsmocks"
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
+	"github.com/UpdateHub/updatehub/testsmocks/copymock"
+	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
+	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
+	"github.com/UpdateHub/updatehub/testsmocks/ubifsmock"
 	"github.com/UpdateHub/updatehub/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -103,7 +107,7 @@ func TestUbifsSetupWithUbivolumeTargetType(t *testing.T) {
 }
 
 func TestUbifsSetupWithNotSupportedTargetTypes(t *testing.T) {
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 
 	ufs := UbifsObject{CmdLineExecuter: clm}
 
@@ -129,12 +133,12 @@ func TestUbifsInstallWithSuccessNonCompressed(t *testing.T) {
 	targetDevice := "/dev/mtd3"
 	sha256sum := "71c88745e5a72067f94aae0ecec6d45af8b0f6e1a37ef695df0b56711e192b86"
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", fmt.Sprintf("ubiupdatevol %s %s", targetDevice, sha256sum)).Return([]byte("combinedoutput"), nil)
 
-	fsm := &testsmocks.FileSystemBackendMock{}
+	fsm := &filesystemmock.FileSystemBackendMock{}
 
-	uum := &testsmocks.UbifsUtilsMock{}
+	uum := &ubifsmock.UbifsUtilsMock{}
 	uum.On("GetTargetDeviceFromUbiVolumeName", fsm, ubivolume).Return(targetDevice, nil)
 
 	ufs := UbifsObject{
@@ -163,16 +167,16 @@ func TestUbifsInstallWithSuccessCompressed(t *testing.T) {
 	uncompressedSize := 12345678.0
 	cmdline := fmt.Sprintf("ubiupdatevol -s %.0f %s -", uncompressedSize, targetDevice)
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 
-	fsm := &testsmocks.FileSystemBackendMock{}
+	fsm := &filesystemmock.FileSystemBackendMock{}
 
-	uum := &testsmocks.UbifsUtilsMock{}
+	uum := &ubifsmock.UbifsUtilsMock{}
 	uum.On("GetTargetDeviceFromUbiVolumeName", fsm, ubivolume).Return(targetDevice, nil)
 
-	lam := &testsmocks.LibArchiveMock{}
+	lam := &libarchivemock.LibArchiveMock{}
 
-	cpm := &testsmocks.CopierMock{}
+	cpm := &copymock.CopierMock{}
 	cpm.On("CopyToProcessStdin", fsm, lam, srcPath, cmdline, compressed).Return(nil)
 
 	ufs := UbifsObject{
@@ -207,16 +211,16 @@ func TestUbifsInstallWithCopyToProcessStdinFailure(t *testing.T) {
 	uncompressedSize := 12345678.0
 	cmdline := fmt.Sprintf("ubiupdatevol -s %.0f %s -", uncompressedSize, targetDevice)
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 
-	fsm := &testsmocks.FileSystemBackendMock{}
+	fsm := &filesystemmock.FileSystemBackendMock{}
 
-	uum := &testsmocks.UbifsUtilsMock{}
+	uum := &ubifsmock.UbifsUtilsMock{}
 	uum.On("GetTargetDeviceFromUbiVolumeName", fsm, ubivolume).Return(targetDevice, nil)
 
-	lam := &testsmocks.LibArchiveMock{}
+	lam := &libarchivemock.LibArchiveMock{}
 
-	cpm := &testsmocks.CopierMock{}
+	cpm := &copymock.CopierMock{}
 	cpm.On("CopyToProcessStdin", fsm, lam, srcPath, cmdline, compressed).Return(fmt.Errorf("process error"))
 
 	ufs := UbifsObject{
@@ -247,11 +251,11 @@ func TestUbifsInstallWithGetTargetDeviceFromUbiVolumeNameFailure(t *testing.T) {
 	compressed := false
 	sha256sum := "71c88745e5a72067f94aae0ecec6d45af8b0f6e1a37ef695df0b56711e192b86"
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 
-	fsm := &testsmocks.FileSystemBackendMock{}
+	fsm := &filesystemmock.FileSystemBackendMock{}
 
-	uum := &testsmocks.UbifsUtilsMock{}
+	uum := &ubifsmock.UbifsUtilsMock{}
 	uum.On("GetTargetDeviceFromUbiVolumeName", fsm, ubivolume).Return("", fmt.Errorf("UBI volume '%s' wasn't found", ubivolume))
 
 	ufs := UbifsObject{
@@ -277,12 +281,12 @@ func TestUbifsInstallWithUbiUpdateVolFailure(t *testing.T) {
 	targetDevice := "/dev/mtd3"
 	sha256sum := "71c88745e5a72067f94aae0ecec6d45af8b0f6e1a37ef695df0b56711e192b86"
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", fmt.Sprintf("ubiupdatevol %s %s", targetDevice, sha256sum)).Return([]byte("error"), fmt.Errorf("Error executing command"))
 
-	fsm := &testsmocks.FileSystemBackendMock{}
+	fsm := &filesystemmock.FileSystemBackendMock{}
 
-	uum := &testsmocks.UbifsUtilsMock{}
+	uum := &ubifsmock.UbifsUtilsMock{}
 	uum.On("GetTargetDeviceFromUbiVolumeName", fsm, ubivolume).Return(targetDevice, nil)
 
 	ufs := UbifsObject{

--- a/testsmocks/cmdlinemock/executer.go
+++ b/testsmocks/cmdlinemock/executer.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package cmdlinemock
 
 import "github.com/stretchr/testify/mock"
 

--- a/testsmocks/copymock/copy.go
+++ b/testsmocks/copymock/copy.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package copymock
 
 import (
 	"io"

--- a/testsmocks/filemock/file.go
+++ b/testsmocks/filemock/file.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package filemock
 
 import (
 	"os"

--- a/testsmocks/filesystemmock/backend.go
+++ b/testsmocks/filesystemmock/backend.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package filesystemmock
 
 import (
 	"os"

--- a/testsmocks/filesystemmock/helper.go
+++ b/testsmocks/filesystemmock/helper.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package filesystemmock
 
 import "github.com/stretchr/testify/mock"
 

--- a/testsmocks/libarchivemock/libarchive.go
+++ b/testsmocks/libarchivemock/libarchive.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package libarchivemock
 
 import (
 	"github.com/UpdateHub/updatehub/libarchive"

--- a/testsmocks/mtdmock/mtd.go
+++ b/testsmocks/mtdmock/mtd.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package mtdmock
 
 import (
 	"github.com/spf13/afero"

--- a/testsmocks/ubifsmock/ubifs.go
+++ b/testsmocks/ubifsmock/ubifs.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package testsmocks
+package ubifsmock
 
 import (
 	"github.com/spf13/afero"

--- a/utils/copy_test.go
+++ b/utils/copy_test.go
@@ -22,7 +22,9 @@ import (
 	"time"
 
 	"github.com/UpdateHub/updatehub/libarchive"
-	"github.com/UpdateHub/updatehub/testsmocks"
+	"github.com/UpdateHub/updatehub/testsmocks/filemock"
+	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
+	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -341,7 +343,7 @@ func TestCopyFileWithSuccess(t *testing.T) {
 		chunkSize = 128 * 1024
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceContent := []uint8("test")
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -353,7 +355,7 @@ func TestCopyFileWithSuccess(t *testing.T) {
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Return(0, io.EOF).Once()
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -362,12 +364,12 @@ func TestCopyFileWithSuccess(t *testing.T) {
 	}).Return(len(targetContent), nil).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, -1, true, false)
 	assert.NoError(t, err)
 
@@ -383,7 +385,7 @@ func TestCopyFileWithSuccessWithMultipleChunks(t *testing.T) {
 		chunkSize = 2
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceContent := []uint8("test")
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -399,7 +401,7 @@ func TestCopyFileWithSuccessWithMultipleChunks(t *testing.T) {
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Return(0, io.EOF).Once()
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -412,12 +414,12 @@ func TestCopyFileWithSuccessWithMultipleChunks(t *testing.T) {
 	}).Return(chunkSize, nil).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, -1, true, false)
 	assert.NoError(t, err)
 
@@ -435,7 +437,7 @@ func TestCopyFileWithSuccessUsingSkipAndSeek(t *testing.T) {
 		chunkSize = 4
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	readContent := []uint8("test")
 	sourceMock.On("Seek", int64(skip*chunkSize), io.SeekStart).Return(int64(skip*chunkSize), nil)
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -447,7 +449,7 @@ func TestCopyFileWithSuccessUsingSkipAndSeek(t *testing.T) {
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Return(0, io.EOF).Once()
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	writeContent := []uint8("")
 	targetMock.On("Seek", int64(seek*chunkSize), io.SeekStart).Return(int64(skip*chunkSize), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -456,12 +458,12 @@ func TestCopyFileWithSuccessUsingSkipAndSeek(t *testing.T) {
 	}).Return(len(writeContent), nil).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		skip, seek, -1, true, false)
 	assert.NoError(t, err)
 
@@ -478,7 +480,7 @@ func TestCopyFileUsingCount(t *testing.T) {
 		count     = 3
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceContent := []uint8("test")
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 
@@ -492,7 +494,7 @@ func TestCopyFileUsingCount(t *testing.T) {
 
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 
@@ -505,12 +507,12 @@ func TestCopyFileUsingCount(t *testing.T) {
 
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, count, true, false)
 	assert.NoError(t, err)
 
@@ -528,7 +530,7 @@ func TestCopyFileUsingNegativeCount(t *testing.T) {
 		count     = -1
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceContent := []uint8("test")
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 
@@ -543,7 +545,7 @@ func TestCopyFileUsingNegativeCount(t *testing.T) {
 
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 
@@ -556,12 +558,12 @@ func TestCopyFileUsingNegativeCount(t *testing.T) {
 
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, count, true, false)
 	assert.NoError(t, err)
 
@@ -577,7 +579,7 @@ func TestCopyFileNotUsingTruncate(t *testing.T) {
 		truncate = false
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceContent := []uint8("test")
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -587,7 +589,7 @@ func TestCopyFileNotUsingTruncate(t *testing.T) {
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Return(0, io.EOF).Once()
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -596,12 +598,12 @@ func TestCopyFileNotUsingTruncate(t *testing.T) {
 	}).Return(len(targetContent), nil).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
 		0, 0, -1, truncate, false)
 	assert.NoError(t, err)
 
@@ -613,7 +615,7 @@ func TestCopyFileNotUsingTruncate(t *testing.T) {
 }
 
 func TestCopyFileWithOpenError(t *testing.T) {
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
@@ -623,12 +625,12 @@ func TestCopyFileWithOpenError(t *testing.T) {
 		Err:  syscall.ENOSPC,
 	}
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
-	fom.On("Open", "source.txt").Return((*testsmocks.FileMock)(nil), pathError)
+	fom.On("Open", "source.txt").Return((*filemock.FileMock)(nil), pathError)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "open source.txt: no space left on device")
 
@@ -643,11 +645,11 @@ func TestCopyFileWithOpenFileError(t *testing.T) {
 		Err:  syscall.ENOSPC,
 	}
 
-	fom := &testsmocks.FileSystemBackendMock{}
-	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return((*testsmocks.FileMock)(nil), pathError)
+	fom := &filesystemmock.FileSystemBackendMock{}
+	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return((*filemock.FileMock)(nil), pathError)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "open target.txt: no space left on device")
 
@@ -655,21 +657,21 @@ func TestCopyFileWithOpenFileError(t *testing.T) {
 }
 
 func TestCopyFileWithReadError(t *testing.T) {
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Return(0, io.ErrClosedPipe).Once()
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "io: read/write on closed pipe")
 
@@ -679,7 +681,7 @@ func TestCopyFileWithReadError(t *testing.T) {
 }
 
 func TestCopyFileWithWriteError(t *testing.T) {
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceContent := []uint8("test")
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Read", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -688,7 +690,7 @@ func TestCopyFileWithWriteError(t *testing.T) {
 	}).Return(len(sourceContent), nil).Once()
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -697,12 +699,12 @@ func TestCopyFileWithWriteError(t *testing.T) {
 	}).Return(0, io.ErrClosedPipe).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "io: read/write on closed pipe")
 
@@ -718,20 +720,20 @@ func TestCopyFileWithZeroedChunkSize(t *testing.T) {
 		chunkSize = 0
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "Copy error: chunkSize can't be less than 1")
 
@@ -745,20 +747,20 @@ func TestCopyFileWithNegativeChunkSize(t *testing.T) {
 		chunkSize = -1
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "Copy error: chunkSize can't be less than 1")
 
@@ -772,20 +774,20 @@ func TestCustomCopyFileWithSkipError(t *testing.T) {
 		chunkSize = 128 * 1024
 	)
 
-	sourceMock := &testsmocks.FileMock{}
+	sourceMock := &filemock.FileMock{}
 	sourceMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), fmt.Errorf("Seek: invalid whence"))
 	sourceMock.On("Close").Return(nil)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("Open", "source.txt").Return(sourceMock, nil)
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "Seek: invalid whence")
 
@@ -799,15 +801,15 @@ func TestCopyFileWithSeekError(t *testing.T) {
 		chunkSize = 128 * 1024
 	)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), fmt.Errorf("Seek: invalid whence"))
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &testsmocks.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", chunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "Seek: invalid whence")
 
@@ -821,7 +823,7 @@ func TestCopyFileWithSuccessUsingLibarchive(t *testing.T) {
 		sourcePath = "source.gz"
 	)
 
-	libarchiveMock := &testsmocks.LibArchiveMock{}
+	libarchiveMock := &libarchivemock.LibArchiveMock{}
 
 	sourceContent := []uint8("test")
 
@@ -841,7 +843,7 @@ func TestCopyFileWithSuccessUsingLibarchive(t *testing.T) {
 	libarchiveMock.On("ReadData", a, mock.AnythingOfType("[]uint8"), chunkSize).Return(0, nil).Once()
 	libarchiveMock.On("ReadFree", a)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -850,7 +852,7 @@ func TestCopyFileWithSuccessUsingLibarchive(t *testing.T) {
 	}).Return(len(targetContent), nil).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
@@ -871,7 +873,7 @@ func TestCopyFileWithLibarchiveReadOpenFileNameError(t *testing.T) {
 		sourcePath = "source.gz"
 	)
 
-	libarchiveMock := &testsmocks.LibArchiveMock{}
+	libarchiveMock := &libarchivemock.LibArchiveMock{}
 
 	a := libarchive.LibArchive{}.NewRead()
 	libarchiveMock.On("NewRead").Return(a)
@@ -881,12 +883,12 @@ func TestCopyFileWithLibarchiveReadOpenFileNameError(t *testing.T) {
 	libarchiveMock.On("ReadOpenFileName", a, sourcePath, chunkSize).Return(fmt.Errorf("Failed to open '%s'", sourcePath))
 	libarchiveMock.On("ReadFree", a)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
@@ -907,7 +909,7 @@ func TestCopyFileWithLibarchiveReadNextHeaderError(t *testing.T) {
 		sourcePath = "source.gz"
 	)
 
-	libarchiveMock := &testsmocks.LibArchiveMock{}
+	libarchiveMock := &libarchivemock.LibArchiveMock{}
 
 	a := libarchive.LibArchive{}.NewRead()
 	libarchiveMock.On("NewRead").Return(a)
@@ -918,12 +920,12 @@ func TestCopyFileWithLibarchiveReadNextHeaderError(t *testing.T) {
 	libarchiveMock.On("ReadNextHeader", a, mock.AnythingOfType("*libarchive.ArchiveEntry")).Return(fmt.Errorf("Mock emulated error"))
 	libarchiveMock.On("ReadFree", a)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
@@ -944,7 +946,7 @@ func TestCopyFileWithLibarchiveReadDataError(t *testing.T) {
 		sourcePath = "source.gz"
 	)
 
-	libarchiveMock := &testsmocks.LibArchiveMock{}
+	libarchiveMock := &libarchivemock.LibArchiveMock{}
 
 	a := libarchive.LibArchive{}.NewRead()
 	libarchiveMock.On("NewRead").Return(a)
@@ -956,12 +958,12 @@ func TestCopyFileWithLibarchiveReadDataError(t *testing.T) {
 	libarchiveMock.On("ReadData", a, mock.AnythingOfType("[]uint8"), chunkSize).Return(-30, fmt.Errorf("Mock emulated error")).Once()
 	libarchiveMock.On("ReadFree", a)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
@@ -982,7 +984,7 @@ func TestCopyFileWithLibarchiveWriteError(t *testing.T) {
 		sourcePath = "source.gz"
 	)
 
-	libarchiveMock := &testsmocks.LibArchiveMock{}
+	libarchiveMock := &libarchivemock.LibArchiveMock{}
 
 	sourceContent := []uint8("test")
 	a := libarchive.LibArchive{}.NewRead()
@@ -1000,7 +1002,7 @@ func TestCopyFileWithLibarchiveWriteError(t *testing.T) {
 	}).Return(len(sourceContent), nil).Once()
 	libarchiveMock.On("ReadFree", a)
 
-	targetMock := &testsmocks.FileMock{}
+	targetMock := &filemock.FileMock{}
 	targetContent := []uint8("")
 	targetMock.On("Seek", int64(0), io.SeekStart).Return(int64(0), nil)
 	targetMock.On("Write", mock.AnythingOfType("[]uint8")).Run(func(args mock.Arguments) {
@@ -1009,7 +1011,7 @@ func TestCopyFileWithLibarchiveWriteError(t *testing.T) {
 	}).Return(0, io.ErrClosedPipe).Once()
 	targetMock.On("Close").Return(nil)
 
-	fom := &testsmocks.FileSystemBackendMock{}
+	fom := &filesystemmock.FileSystemBackendMock{}
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}

--- a/utils/ubifs_test.go
+++ b/utils/ubifs_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/UpdateHub/updatehub/testsmocks"
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,7 +34,7 @@ func TestUbifsUtilsImplWithASingleDeviceNode(t *testing.T) {
 	memFs.MkdirAll("/dev", 0755)
 	afero.WriteFile(memFs, fmt.Sprintf("/dev/ubi%d", deviceNumber), []byte("ubi_content"), 0755)
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", fmt.Sprintf("ubinfo -d %d -N %s", deviceNumber, ubivolume)).Return([]byte(fmt.Sprintf(ubinfoStdoutTemplate, volumeID, deviceNumber, ubivolume)), nil)
 
 	uui := &UbifsUtilsImpl{CmdLineExecuter: clm}
@@ -57,7 +57,7 @@ func TestUbifsUtilsImplWithMultipleUbiDeviceNodes(t *testing.T) {
 	afero.WriteFile(memFs, fmt.Sprintf("/dev/ubi%d", deviceNumber), []byte("ubi_content"), 0755)
 	afero.WriteFile(memFs, fmt.Sprintf("/dev/ubi%d", deviceNumber+1), []byte("ubi_content"), 0755)
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 	clm.On("Execute", fmt.Sprintf("ubinfo -d %d -N %s", deviceNumber-1, ubivolume)).Return([]byte(""), fmt.Errorf("Error executing command"))
 	clm.On("Execute", fmt.Sprintf("ubinfo -d %d -N %s", deviceNumber, ubivolume)).Return([]byte(fmt.Sprintf(ubinfoStdoutTemplate, volumeID, deviceNumber, ubivolume)), nil)
 
@@ -76,7 +76,7 @@ func TestUbifsUtilsImplWithReadDirFailure(t *testing.T) {
 	memFs := afero.NewMemMapFs()
 	memFs.RemoveAll("/dev")
 
-	clm := &testsmocks.CmdLineExecuterMock{}
+	clm := &cmdlinemock.CmdLineExecuterMock{}
 
 	uui := &UbifsUtilsImpl{CmdLineExecuter: clm}
 	targetDevice, err := uui.GetTargetDeviceFromUbiVolumeName(memFs, ubivolume)


### PR DESCRIPTION
This will help avoid import cycles with the testsmocks package.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>