### PR TITLE
Don't multiply elapsed by seconds cause it is already in duration

### DIFF
--- a/states_test.go
+++ b/states_test.go
@@ -169,7 +169,7 @@ func TestPollingRetries(t *testing.T) {
 				C: c,
 			}
 
-			c <- time.Now().Add(elapsed * time.Second)
+			c <- time.Now().Add(elapsed)
 
 			return ticker
 		})


### PR DESCRIPTION
Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>