### PR TITLE
install-if-different partial implementation

### DIFF
--- a/installifdifferent/installifdifferent.go
+++ b/installifdifferent/installifdifferent.go
@@ -1,0 +1,80 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package installifdifferent
+
+import (
+	"fmt"
+
+	"github.com/UpdateHub/updatehub/installmodes"
+	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/spf13/afero"
+)
+
+type Interface interface {
+	Proceed(o metadata.Object) (bool, error)
+}
+
+type DefaultImpl struct {
+	FileSystemBackend afero.Fs
+}
+
+func (iid *DefaultImpl) Proceed(o metadata.Object) (bool, error) {
+	om, err := installmodes.GetObject(o.GetObjectMetadata().Mode)
+	if err != nil {
+		return false, err
+	}
+
+	tg, ok := om.(TargetGetter)
+
+	if !ok {
+		// "o" does NOT support install-if-different
+		return true, nil
+	}
+
+	// "o" does support install-if-different
+
+	target := tg.GetTarget()
+
+	exists, err := afero.Exists(iid.FileSystemBackend, target)
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		return false, fmt.Errorf("install-if-different: target '%s' not found", target)
+	}
+
+	sha256sum, ok := o.GetObjectMetadata().InstallIfDifferent.(string)
+	if ok {
+		// is string, so is a Sha256Sum
+		return installIfDifferentSha256Sum(target, sha256sum)
+	}
+
+	pattern, ok := o.GetObjectMetadata().InstallIfDifferent.(map[string]interface{})
+	if ok {
+		// is object, so is a Pattern
+		return installIfDifferentPattern(target, pattern)
+	}
+
+	return false, fmt.Errorf("unknown install-if-different format")
+}
+
+type TargetGetter interface {
+	GetTarget() string
+}
+
+func installIfDifferentSha256Sum(target string, sha256sum string) (bool, error) {
+	// FIXME: implement this
+	return false, fmt.Errorf("installIfDifferent: Sha256Sum not yet implemented")
+}
+
+func installIfDifferentPattern(target string, pattern map[string]interface{}) (bool, error) {
+	// FIXME: implement this
+	return false, fmt.Errorf("installIfDifferent: Pattern not yet implemented")
+}

--- a/installifdifferent/installifdifferent_test.go
+++ b/installifdifferent/installifdifferent_test.go
@@ -1,0 +1,209 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package installifdifferent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/UpdateHub/updatehub/installmodes"
+	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ObjectWithInstallIfDifferentSha256Sum = `{
+        "mode": "test",
+        "target": "/tmp/dev/xx1",
+        "target-type": "device",
+        "target-path": "/path",
+        "install-if-different": "73a625b0271d75702cc4205061da9efc6112e9fe94033ed0f9033157109ebe75"
+	}`
+
+	ObjectWithInstallIfDifferentPattern = `{
+        "mode": "test",
+        "target": "/tmp/dev/xx1",
+        "target-type": "device",
+        "target-path": "/path",
+        "install-if-different": {
+            "version": "2.0",
+            "pattern": {
+                "regexp": ".+",
+                "seek": 1024,
+                "buffer-size": 2024
+            },
+            "extra": "property"
+        }
+	}`
+
+	ObjectWithoutInstallIfDifferent = `{
+        "mode": "test",
+        "target": "/tmp/dev/xx1",
+        "target-type": "device",
+        "target-path": "/path"
+	}`
+
+	ObjectWithInstallIfDifferentUnknownFormat = `{
+        "mode": "test",
+        "target": "/tmp/dev/xx1",
+        "target-type": "device",
+        "target-path": "/path",
+        "install-if-different": [ 1, 2, 3 ]
+	}`
+
+	testObjectGetTargetReturn = "/tmp/get-target-return"
+)
+
+type testObject struct {
+	metadata.ObjectMetadata
+	TargetGetter
+}
+
+func (to *testObject) GetTarget() string {
+	return testObjectGetTargetReturn
+}
+
+type testObjectWithoutIIDSupport struct {
+	metadata.ObjectMetadata
+}
+
+func TestProceedWithoutInstallIfDifferentSupport(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+
+	err := afero.WriteFile(memFs, testObjectGetTargetReturn, []byte("dummy"), 0666)
+	assert.NoError(t, err)
+	defer memFs.Remove(testObjectGetTargetReturn)
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return &testObjectWithoutIIDSupport{} },
+	})
+	defer mode.Unregister()
+
+	iif := &DefaultImpl{memFs}
+
+	o, err := metadata.NewObjectMetadata([]byte(ObjectWithoutInstallIfDifferent))
+	assert.NoError(t, err)
+
+	install, err := iif.Proceed(o)
+	assert.NoError(t, err)
+	assert.True(t, install)
+}
+
+func TestProceedWithSha256Sum(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+
+	err := afero.WriteFile(memFs, testObjectGetTargetReturn, []byte("dummy"), 0666)
+	assert.NoError(t, err)
+	defer memFs.Remove(testObjectGetTargetReturn)
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return &testObject{} },
+	})
+	defer mode.Unregister()
+
+	iif := &DefaultImpl{memFs}
+
+	o, err := metadata.NewObjectMetadata([]byte(ObjectWithInstallIfDifferentSha256Sum))
+	assert.NoError(t, err)
+
+	install, err := iif.Proceed(o)
+	/*
+		    FIXME: this is supposed to be successful like this commented
+		    asserts. We are testing for "non-implemented yet" temporarily as
+		    an itermediate step since this feature is enormous.
+
+			assert.NoError(t, err)
+			assert.True(t, install)
+	*/
+
+	assert.EqualError(t, err, "installIfDifferent: Sha256Sum not yet implemented")
+	assert.False(t, install)
+}
+
+func TestProceedWithPattern(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+
+	err := afero.WriteFile(memFs, testObjectGetTargetReturn, []byte("dummy"), 0666)
+	assert.NoError(t, err)
+	defer memFs.Remove(testObjectGetTargetReturn)
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return &testObject{} },
+	})
+	defer mode.Unregister()
+
+	iif := &DefaultImpl{memFs}
+
+	o, err := metadata.NewObjectMetadata([]byte(ObjectWithInstallIfDifferentPattern))
+	assert.NoError(t, err)
+
+	install, err := iif.Proceed(o)
+	/*
+		    FIXME: this is supposed to be successful like this commented
+		    asserts. We are testing for "non-implemented yet" temporarily as
+		    an itermediate step since this feature is enormous.
+
+			assert.NoError(t, err)
+			assert.True(t, install)
+	*/
+
+	assert.EqualError(t, err, "installIfDifferent: Pattern not yet implemented")
+	assert.False(t, install)
+}
+
+func TestProceedWithUnknownFormatError(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+
+	err := afero.WriteFile(memFs, testObjectGetTargetReturn, []byte("dummy"), 0666)
+	assert.NoError(t, err)
+	defer memFs.Remove(testObjectGetTargetReturn)
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return &testObject{} },
+	})
+	defer mode.Unregister()
+
+	iif := &DefaultImpl{memFs}
+
+	o, err := metadata.NewObjectMetadata([]byte(ObjectWithInstallIfDifferentUnknownFormat))
+	assert.NoError(t, err)
+
+	install, err := iif.Proceed(o)
+	assert.EqualError(t, err, "unknown install-if-different format")
+	assert.False(t, install)
+}
+
+func TestProceedWithTargetNotFoundError(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return &testObject{} },
+	})
+	defer mode.Unregister()
+
+	iif := &DefaultImpl{memFs}
+
+	o, err := metadata.NewObjectMetadata([]byte(ObjectWithInstallIfDifferentUnknownFormat))
+	assert.NoError(t, err)
+
+	install, err := iif.Proceed(o)
+	assert.EqualError(t, err, fmt.Sprintf("install-if-different: target '%s' not found", testObjectGetTargetReturn))
+	assert.False(t, install)
+}

--- a/installmodes/copy/copy_test.go
+++ b/installmodes/copy/copy_test.go
@@ -90,6 +90,8 @@ func TestCopyInstallWithFormatError(t *testing.T) {
 	fsm.AssertExpectations(t)
 	cm.AssertExpectations(t)
 	lam.AssertExpectations(t)
+
+	assert.Equal(t, "", cp.GetTarget())
 }
 
 func TestCopyInstallWithTempDirError(t *testing.T) {
@@ -107,6 +109,8 @@ func TestCopyInstallWithTempDirError(t *testing.T) {
 	fsm.AssertExpectations(t)
 	cm.AssertExpectations(t)
 	lam.AssertExpectations(t)
+
+	assert.Equal(t, "", cp.GetTarget())
 }
 
 func TestCopyInstallWithMountError(t *testing.T) {
@@ -139,6 +143,8 @@ func TestCopyInstallWithMountError(t *testing.T) {
 	tempDirExists, err := afero.Exists(memFs, tempDirPath)
 	assert.False(t, tempDirExists)
 	assert.NoError(t, err)
+
+	assert.Equal(t, "", cp.GetTarget())
 }
 
 func TestCopyInstallWithCopyFileError(t *testing.T) {
@@ -189,6 +195,9 @@ func TestCopyInstallWithCopyFileError(t *testing.T) {
 	tempDirExists, err := afero.Exists(memFs, tempDirPath)
 	assert.False(t, tempDirExists)
 	assert.NoError(t, err)
+
+	expectedTargetPath := path.Join(tempDirPath, targetPath)
+	assert.Equal(t, expectedTargetPath, cp.GetTarget())
 }
 
 func TestCopyInstallWithUmountError(t *testing.T) {
@@ -239,6 +248,9 @@ func TestCopyInstallWithUmountError(t *testing.T) {
 	tempDirExists, err := afero.Exists(memFs, tempDirPath)
 	assert.True(t, tempDirExists)
 	assert.NoError(t, err)
+
+	expectedTargetPath := path.Join(tempDirPath, targetPath)
+	assert.Equal(t, expectedTargetPath, cp.GetTarget())
 }
 
 func TestCopyInstallWithCopyFileANDUmountErrors(t *testing.T) {
@@ -289,6 +301,9 @@ func TestCopyInstallWithCopyFileANDUmountErrors(t *testing.T) {
 	tempDirExists, err := afero.Exists(memFs, tempDirPath)
 	assert.True(t, tempDirExists)
 	assert.NoError(t, err)
+
+	expectedTargetPath := path.Join(tempDirPath, targetPath)
+	assert.Equal(t, expectedTargetPath, cp.GetTarget())
 }
 
 func TestCopyInstallWithSuccess(t *testing.T) {
@@ -407,6 +422,9 @@ func TestCopyInstallWithSuccess(t *testing.T) {
 			tempDirExists, err := afero.Exists(memFs, tempDirPath)
 			assert.False(t, tempDirExists)
 			assert.NoError(t, err)
+
+			expectedTargetPath := path.Join(tempDirPath, tc.TargetPath)
+			assert.Equal(t, expectedTargetPath, cp.GetTarget())
 		})
 	}
 }

--- a/installmodes/flash/flash.go
+++ b/installmodes/flash/flash.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/utils"
@@ -53,6 +54,7 @@ type FlashObject struct {
 	utils.CmdLineExecuter
 	FileSystemBackend afero.Fs
 	utils.MtdUtils
+	installifdifferent.TargetGetter
 
 	Target     string `json:"target"`
 	TargetType string `json:"target-type"`
@@ -109,4 +111,7 @@ func (f *FlashObject) Cleanup() error {
 	return nil
 }
 
-// FIXME: install-different stuff?
+// GetTarget implementation for the "flash" handler
+func (f *FlashObject) GetTarget() string {
+	return f.targetDevice + "ro"
+}

--- a/installmodes/flash/flash_test.go
+++ b/installmodes/flash/flash_test.go
@@ -210,6 +210,9 @@ func TestFlashInstallSuccessWithNAND(t *testing.T) {
 
 	mum.AssertExpectations(t)
 	clm.AssertExpectations(t)
+
+	expectedTargetDevice := mtddevice + "ro"
+	assert.Equal(t, expectedTargetDevice, f.GetTarget())
 }
 
 func TestFlashInstallSuccessWithNOR(t *testing.T) {
@@ -235,6 +238,9 @@ func TestFlashInstallSuccessWithNOR(t *testing.T) {
 
 	mum.AssertExpectations(t)
 	clm.AssertExpectations(t)
+
+	expectedTargetDevice := mtddevice + "ro"
+	assert.Equal(t, expectedTargetDevice, f.GetTarget())
 }
 
 func TestFlashInstallWithMtdIsNANDFailure(t *testing.T) {
@@ -258,6 +264,9 @@ func TestFlashInstallWithMtdIsNANDFailure(t *testing.T) {
 
 	mum.AssertExpectations(t)
 	clm.AssertExpectations(t)
+
+	expectedTargetDevice := mtddevice + "ro"
+	assert.Equal(t, expectedTargetDevice, f.GetTarget())
 }
 
 func TestFlashInstallWithFlashEraseFailure(t *testing.T) {
@@ -281,6 +290,9 @@ func TestFlashInstallWithFlashEraseFailure(t *testing.T) {
 
 	mum.AssertExpectations(t)
 	clm.AssertExpectations(t)
+
+	expectedTargetDevice := mtddevice + "ro"
+	assert.Equal(t, expectedTargetDevice, f.GetTarget())
 }
 
 func TestFlashInstallWithFlashcpFailure(t *testing.T) {
@@ -306,6 +318,9 @@ func TestFlashInstallWithFlashcpFailure(t *testing.T) {
 
 	mum.AssertExpectations(t)
 	clm.AssertExpectations(t)
+
+	expectedTargetDevice := mtddevice + "ro"
+	assert.Equal(t, expectedTargetDevice, f.GetTarget())
 }
 
 func TestFlashInstallWithNandwriteFailure(t *testing.T) {
@@ -331,4 +346,7 @@ func TestFlashInstallWithNandwriteFailure(t *testing.T) {
 
 	mum.AssertExpectations(t)
 	clm.AssertExpectations(t)
+
+	expectedTargetDevice := mtddevice + "ro"
+	assert.Equal(t, expectedTargetDevice, f.GetTarget())
 }

--- a/installmodes/imxkobs/imxkobs.go
+++ b/installmodes/imxkobs/imxkobs.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strconv"
 
+	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/utils"
@@ -42,6 +43,7 @@ func getObject() interface{} {
 type ImxKobsObject struct {
 	metadata.ObjectMetadata
 	utils.CmdLineExecuter
+	installifdifferent.TargetGetter
 
 	Add1KPadding    bool   `json:"1k_padding,omitempty"`
 	SearchExponent  int    `json:"search_exponent,omitempty"`
@@ -88,4 +90,13 @@ func (ik *ImxKobsObject) Cleanup() error {
 	return nil
 }
 
-// FIXME: install-different stuff?
+// GetTarget implementation for the "imxkobs" handler
+func (ik *ImxKobsObject) GetTarget() string {
+	mtdDevicePath := "/dev/mtd0"
+
+	if ik.Chip0DevicePath != "" {
+		mtdDevicePath = ik.Chip0DevicePath
+	}
+
+	return mtdDevicePath + "ro"
+}

--- a/installmodes/imxkobs/imxkobs_test.go
+++ b/installmodes/imxkobs/imxkobs_test.go
@@ -182,6 +182,8 @@ func TestImxKobsInstallSuccessCases(t *testing.T) {
 			assert.NoError(t, err)
 
 			clm.AssertExpectations(t)
+
+			assert.Equal(t, "/dev/mtd0ro", ik.GetTarget())
 		})
 	}
 }
@@ -210,4 +212,19 @@ func TestImxKobsInstallFailure(t *testing.T) {
 	assert.EqualError(t, err, "Error executing 'kobs-ng'. Output: combinedOutput")
 
 	clm.AssertExpectations(t)
+
+	assert.Equal(t, "/dev/mtd0ro", ik.GetTarget())
+}
+
+func TestImxKobsGetTarget(t *testing.T) {
+	clm := &cmdlinemock.CmdLineExecuterMock{}
+
+	ik := ImxKobsObject{CmdLineExecuter: clm}
+
+	// default value
+	assert.Equal(t, "/dev/mtd0ro", ik.GetTarget())
+
+	// chip0 value
+	ik.Chip0DevicePath = "/dev/mtd7"
+	assert.Equal(t, "/dev/mtd7ro", ik.GetTarget())
 }

--- a/installmodes/raw/raw.go
+++ b/installmodes/raw/raw.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/metadata"
@@ -44,6 +45,7 @@ type RawObject struct {
 	LibArchiveBackend libarchive.API `json:"-"`
 	FileSystemBackend afero.Fs
 	utils.Copier      `json:"-"`
+	installifdifferent.TargetGetter
 
 	Target     string `json:"target"`
 	TargetType string `json:"target-type"`
@@ -74,4 +76,7 @@ func (r *RawObject) Cleanup() error {
 	return nil
 }
 
-// FIXME: install-different stuff
+// GetTarget implementation for the "raw" handler
+func (r *RawObject) GetTarget() string {
+	return r.Target
+}

--- a/installmodes/raw/raw_test.go
+++ b/installmodes/raw/raw_test.go
@@ -102,6 +102,8 @@ func TestRawInstallWithCopyFileError(t *testing.T) {
 	cm.AssertExpectations(t)
 	lam.AssertExpectations(t)
 	fsbm.AssertExpectations(t)
+
+	assert.Equal(t, targetDevice, r.GetTarget())
 }
 
 func TestRawInstallWithSuccess(t *testing.T) {
@@ -162,6 +164,8 @@ func TestRawInstallWithSuccess(t *testing.T) {
 			cm.AssertExpectations(t)
 			lam.AssertExpectations(t)
 			fsbm.AssertExpectations(t)
+
+			assert.Equal(t, tc.Target, r.GetTarget())
 		})
 	}
 }

--- a/metadata/object.go
+++ b/metadata/object.go
@@ -21,9 +21,10 @@ import (
 type ObjectMetadata struct {
 	Object `json:"-"`
 
-	Sha256sum  string `json:"sha256sum"`
-	Mode       string `json:"mode"`
-	Compressed bool   `json:"bool"`
+	Sha256sum          string      `json:"sha256sum"`
+	Mode               string      `json:"mode"`
+	Compressed         bool        `json:"bool"`
+	InstallIfDifferent interface{} `json:"install-if-different,omitempty"`
 }
 
 func NewObjectMetadata(bytes []byte) (Object, error) {

--- a/testsmocks/installifdifferentmock/installifdifferent.go
+++ b/testsmocks/installifdifferentmock/installifdifferent.go
@@ -1,0 +1,23 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package installifdifferentmock
+
+import (
+	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/mock"
+)
+
+type InstallIfDifferentMock struct {
+	mock.Mock
+}
+
+func (iidm *InstallIfDifferentMock) Proceed(o metadata.Object) (bool, error) {
+	args := iidm.Called(o)
+	return args.Bool(0), args.Error(1)
+}


### PR DESCRIPTION
This change includes the major logic of the install-if-different
feature. What is still missing is the specific implementations of
comparations between the target and the sha256sum or pattern received
through json. FIXMEs were left in the code indicating this.

I think it is better to merge this partial implementation now because
this impacts directly on the architecture. The part missing won't
affect nothing else so we can develop it with less conflicts.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>