### PR TITLE
constants: Fix UpdateHub settings and metadata path

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -10,10 +10,10 @@ package main
 
 const (
 	// The system settings are the settings configured in the client-side and will be read-only
-	systemSettingsPath = "/etc/updatehub-agent.conf"
+	systemSettingsPath = "/etc/updatehub.conf"
 	// The runtime settings are the settings that may can change during the execution of UpdateHub
 	// These settings are persisted to keep the behaviour across of device's reboot
-	runtimeSettingsPath = "/var/lib/updatehub-agent.conf"
+	runtimeSettingsPath = "/var/lib/updatehub.conf"
 	// The path on which will be located the scripts that provide the firmware metadata
-	firmwareMetadataDirPath = "/usr/share/updatehub-agent"
+	firmwareMetadataDirPath = "/usr/share/updatehub"
 )


### PR DESCRIPTION
Fix systemSettingsPath, runtimeSettingsPath and firmwareMetadataDirPath
to use correct system location path.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>