### PR TITLE
move libarchive linkage to the "copy" package

### DIFF
--- a/client/update_test.go
+++ b/client/update_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/UpdateHub/updatehub/installmodes/copy"
+	"github.com/UpdateHub/updatehub/installmodes/imxkobs"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/stretchr/testify/assert"
 )
@@ -249,15 +249,15 @@ func TestCheckUpdateWithNoUpdateAvailable(t *testing.T) {
 }
 
 func TestCheckUpdateWithUpdateAvailable(t *testing.T) {
-	// declaration just to register the copy install mode
-	_ = &copy.CopyObject{}
+	// declaration just to register the imxkobs install mode
+	_ = &imxkobs.ImxKobsObject{}
 
 	expectedBody := `{
 	  "product-uid": "0123456789",
 	  "objects": [
 	    [
 	      {
-            "mode": "copy",
+            "mode": "imxkobs",
             "sha256sum": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
           }
 	    ]
@@ -303,7 +303,7 @@ func TestCheckUpdateWithUpdateAvailable(t *testing.T) {
 	// Objects
 	assert.Equal(t, 1, len(um.Objects))
 	assert.Equal(t, 1, len(um.Objects[0]))
-	assert.Equal(t, "copy", um.Objects[0][0].GetObjectMetadata().Mode)
+	assert.Equal(t, "imxkobs", um.Objects[0][0].GetObjectMetadata().Mode)
 	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", um.Objects[0][0].GetObjectMetadata().Sha256sum)
 }
 

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package utils
+package copy
 
 import (
 	"errors"
@@ -16,13 +16,12 @@ import (
 	"time"
 
 	"github.com/UpdateHub/updatehub/libarchive"
+	"github.com/UpdateHub/updatehub/utils"
 	shellwords "github.com/mattn/go-shellwords"
 	"github.com/spf13/afero"
 )
 
-const ChunkSize = 128 * 1024
-
-type Copier interface {
+type Interface interface {
 	Copy(wr io.Writer, rd io.Reader, timeout time.Duration, cancel <-chan bool, chunkSize int, skip int, count int, compressed bool) (bool, error)
 	CopyFile(
 		fsBackend afero.Fs,
@@ -165,7 +164,7 @@ func (eio ExtendedIO) CopyToProcessStdin(
 	}
 
 	err = eio.sharedCopyLogic(fsBackend, libarchiveBackend, processStdin, sourcePath,
-		ChunkSize, 0, -1, compressed)
+		utils.ChunkSize, 0, -1, compressed)
 
 	processStdin.Close()
 

--- a/copy/copy_test.go
+++ b/copy/copy_test.go
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier:     GPL-2.0
  */
 
-package utils
+package copy
 
 import (
 	"bufio"
@@ -25,6 +25,7 @@ import (
 	"github.com/UpdateHub/updatehub/testsmocks/filemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
+	"github.com/UpdateHub/updatehub/utils"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,7 @@ func TestCopy(t *testing.T) {
 	wr := bufio.NewWriter(buff)
 
 	eio := ExtendedIO{}
-	cancelled, err := eio.Copy(wr, rd, time.Minute, nil, ChunkSize, 0, -1, false)
+	cancelled, err := eio.Copy(wr, rd, time.Minute, nil, utils.ChunkSize, 0, -1, false)
 
 	err = wr.Flush()
 	assert.NoError(t, err)
@@ -93,7 +94,7 @@ func TestCopyTimeoutHasReached(t *testing.T) {
 	cancel := make(chan bool)
 
 	eio := ExtendedIO{}
-	cancelled, err := eio.Copy(wr, rd, time.Millisecond, cancel, ChunkSize, 0, -1, false)
+	cancelled, err := eio.Copy(wr, rd, time.Millisecond, cancel, utils.ChunkSize, 0, -1, false)
 	assert.False(t, cancelled)
 	if !assert.Error(t, err) {
 		assert.Equal(t, errors.New("timeout"), err)
@@ -128,7 +129,7 @@ func TestCancelCopy(t *testing.T) {
 
 	go func() {
 		eio := ExtendedIO{}
-		cancelled, err = eio.Copy(wr, rd, time.Minute, cancel, ChunkSize, 0, -1, false)
+		cancelled, err = eio.Copy(wr, rd, time.Minute, cancel, utils.ChunkSize, 0, -1, false)
 		wait <- false
 	}()
 
@@ -171,7 +172,7 @@ func compressData(decompressedData []byte, compressor string) ([]byte, error) {
 		return []byte(nil), err
 	}
 
-	cl := CmdLine{}
+	cl := utils.CmdLine{}
 
 	_, err = cl.Execute(fmt.Sprintf("sh -c \"%s -c %s > %s\"", compressor, tempDecompressed.Name(), tempCompressed.Name()))
 	if err != nil {
@@ -603,7 +604,7 @@ func TestCopyFileNotUsingTruncate(t *testing.T) {
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", utils.ChunkSize,
 		0, 0, -1, truncate, false)
 	assert.NoError(t, err)
 
@@ -630,7 +631,7 @@ func TestCopyFileWithOpenError(t *testing.T) {
 	fom.On("Open", "source.txt").Return((*filemock.FileMock)(nil), pathError)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", utils.ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "open source.txt: no space left on device")
 
@@ -649,7 +650,7 @@ func TestCopyFileWithOpenFileError(t *testing.T) {
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return((*filemock.FileMock)(nil), pathError)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", utils.ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "open target.txt: no space left on device")
 
@@ -671,7 +672,7 @@ func TestCopyFileWithReadError(t *testing.T) {
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", utils.ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "io: read/write on closed pipe")
 
@@ -704,7 +705,7 @@ func TestCopyFileWithWriteError(t *testing.T) {
 	fom.On("OpenFile", "target.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(0666)).Return(targetMock, nil)
 
 	eio := ExtendedIO{}
-	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", ChunkSize,
+	err := eio.CopyFile(fom, &libarchivemock.LibArchiveMock{}, "source.txt", "target.txt", utils.ChunkSize,
 		0, 0, -1, true, false)
 	assert.EqualError(t, err, "io: read/write on closed pipe")
 

--- a/installmodes/copy/copy.go
+++ b/installmodes/copy/copy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
@@ -32,7 +33,7 @@ func init() {
 				},
 				LibArchiveBackend: &libarchive.LibArchive{},
 				FileSystemBackend: afero.NewOsFs(),
-				Copier:            &utils.ExtendedIO{},
+				CopyBackend:       &copy.ExtendedIO{},
 				Permissions:       &utils.PermissionsDefaultImpl{},
 				ChunkSize:         128 * 1024,
 			}
@@ -47,7 +48,7 @@ type CopyObject struct {
 	utils.FileSystemHelper `json:"-"`
 	LibArchiveBackend      libarchive.API `json:"-"`
 	FileSystemBackend      afero.Fs
-	utils.Copier           `json:"-"`
+	CopyBackend            copy.Interface `json:"-"`
 	utils.Permissions
 	installifdifferent.TargetGetter
 	targetPath string
@@ -104,7 +105,7 @@ func (cp *CopyObject) Install(downloadDir string) error {
 	errorList := []error{}
 
 	sourcePath := path.Join(downloadDir, cp.Sha256sum)
-	err = cp.CopyFile(cp.FileSystemBackend, cp.LibArchiveBackend, sourcePath, cp.targetPath, cp.ChunkSize, 0, 0, -1, true, cp.Compressed)
+	err = cp.CopyBackend.CopyFile(cp.FileSystemBackend, cp.LibArchiveBackend, sourcePath, cp.targetPath, cp.ChunkSize, 0, 0, -1, true, cp.Compressed)
 	if err != nil {
 		errorList = append(errorList, err)
 	}

--- a/installmodes/raw/raw.go
+++ b/installmodes/raw/raw.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/metadata"
-	"github.com/UpdateHub/updatehub/utils"
 )
 
 func init() {
@@ -29,7 +29,7 @@ func init() {
 			return &RawObject{
 				LibArchiveBackend: &libarchive.LibArchive{},
 				FileSystemBackend: afero.NewOsFs(),
-				Copier:            &utils.ExtendedIO{},
+				CopyBackend:       &copy.ExtendedIO{},
 				ChunkSize:         128 * 1024,
 				Count:             -1,
 				Truncate:          true,
@@ -44,7 +44,7 @@ type RawObject struct {
 	metadata.CompressedObject
 	LibArchiveBackend libarchive.API `json:"-"`
 	FileSystemBackend afero.Fs
-	utils.Copier      `json:"-"`
+	CopyBackend       copy.Interface `json:"-"`
 	installifdifferent.TargetGetter
 
 	Target     string `json:"target"`
@@ -68,7 +68,7 @@ func (r *RawObject) Setup() error {
 // Install implementation for the "raw" handler
 func (r *RawObject) Install(downloadDir string) error {
 	srcPath := path.Join(downloadDir, r.Sha256sum)
-	return r.CopyFile(r.FileSystemBackend, r.LibArchiveBackend, srcPath, r.Target, r.ChunkSize, r.Skip, r.Seek, r.Count, r.Truncate, r.Compressed)
+	return r.CopyBackend.CopyFile(r.FileSystemBackend, r.LibArchiveBackend, srcPath, r.Target, r.ChunkSize, r.Skip, r.Seek, r.Count, r.Truncate, r.Compressed)
 }
 
 // Cleanup implementation for the "raw" handler

--- a/installmodes/raw/raw_test.go
+++ b/installmodes/raw/raw_test.go
@@ -13,12 +13,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/testsmocks/copymock"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
-	"github.com/UpdateHub/updatehub/utils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,7 +36,7 @@ func TestRawInit(t *testing.T) {
 	r2 := &RawObject{
 		LibArchiveBackend: &libarchive.LibArchive{},
 		FileSystemBackend: osFs,
-		Copier:            &utils.ExtendedIO{},
+		CopyBackend:       &copy.ExtendedIO{},
 		ChunkSize:         128 * 1024,
 		Skip:              0,
 		Seek:              0,
@@ -81,11 +81,11 @@ func TestRawInstallWithCopyFileError(t *testing.T) {
 	downloadDir := "/dummy-download-dir"
 	sourcePath := path.Join(downloadDir, sha256sum)
 
-	cm := &copymock.CopierMock{}
+	cm := &copymock.CopyMock{}
 	cm.On("CopyFile", fsbm, lam, sourcePath, targetDevice, 128*1024, 0, 0, -1, true, compressed).Return(fmt.Errorf("copy file error"))
 
 	r := RawObject{
-		Copier:            cm,
+		CopyBackend:       cm,
 		FileSystemBackend: fsbm,
 		LibArchiveBackend: lam,
 		ChunkSize:         128 * 1024,
@@ -144,10 +144,10 @@ func TestRawInstallWithSuccess(t *testing.T) {
 			downloadDir := "/dummy-download-dir"
 			sourcePath := path.Join(downloadDir, tc.Sha256sum)
 
-			cm := &copymock.CopierMock{}
+			cm := &copymock.CopyMock{}
 			cm.On("CopyFile", fsbm, lam, sourcePath, tc.Target, tc.ExpectedChunkSize, tc.Skip, tc.Seek, tc.Count, tc.Truncate, tc.Compressed).Return(nil)
 
-			r := RawObject{Copier: cm, FileSystemBackend: fsbm, LibArchiveBackend: lam}
+			r := RawObject{CopyBackend: cm, FileSystemBackend: fsbm, LibArchiveBackend: lam}
 			r.Target = tc.Target
 			r.TargetType = tc.TargetType
 			r.Sha256sum = tc.Sha256sum

--- a/installmodes/tarball/tarball.go
+++ b/installmodes/tarball/tarball.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/metadata"
@@ -32,7 +33,7 @@ func init() {
 				},
 				LibArchiveBackend: &libarchive.LibArchive{},
 				FileSystemBackend: afero.NewOsFs(),
-				Copier:            &utils.ExtendedIO{},
+				CopyBackend:       &copy.ExtendedIO{},
 				MtdUtils:          &utils.MtdUtilsImpl{},
 				UbifsUtils: &utils.UbifsUtilsImpl{
 					CmdLineExecuter: cmdline,
@@ -49,7 +50,7 @@ type TarballObject struct {
 	utils.FileSystemHelper `json:"-"`
 	LibArchiveBackend      libarchive.API `json:"-"`
 	FileSystemBackend      afero.Fs
-	utils.Copier           `json:"-"`
+	CopyBackend            copy.Interface `json:"-"`
 	utils.MtdUtils
 	utils.UbifsUtils
 

--- a/installmodes/ubifs/ubifs.go
+++ b/installmodes/ubifs/ubifs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/afero"
 
+	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/metadata"
@@ -45,7 +46,7 @@ func getObject() interface{} {
 
 	return &UbifsObject{
 		CmdLineExecuter:   cle,
-		Copier:            &utils.ExtendedIO{},
+		CopyBackend:       &copy.ExtendedIO{},
 		LibArchiveBackend: &libarchive.LibArchive{},
 		FileSystemBackend: afero.NewOsFs(),
 		UbifsUtils: &utils.UbifsUtilsImpl{
@@ -60,7 +61,7 @@ type UbifsObject struct {
 	metadata.CompressedObject
 	utils.CmdLineExecuter
 	utils.UbifsUtils
-	utils.Copier      `json:"-"`
+	CopyBackend       copy.Interface `json:"-"`
 	LibArchiveBackend libarchive.API `json:"-"`
 	FileSystemBackend afero.Fs
 
@@ -88,7 +89,7 @@ func (ufs *UbifsObject) Install(downloadDir string) error {
 
 	if ufs.Compressed {
 		cmdline := fmt.Sprintf("ubiupdatevol -s %.0f %s -", ufs.UncompressedSize, targetDevice)
-		copyErr := ufs.Copier.CopyToProcessStdin(ufs.FileSystemBackend, ufs.LibArchiveBackend, srcPath, cmdline, ufs.Compressed)
+		copyErr := ufs.CopyBackend.CopyToProcessStdin(ufs.FileSystemBackend, ufs.LibArchiveBackend, srcPath, cmdline, ufs.Compressed)
 		err = copyErr
 	} else {
 		_, execErr := ufs.Execute(fmt.Sprintf("ubiupdatevol %s %s", targetDevice, srcPath))

--- a/installmodes/ubifs/ubifs_test.go
+++ b/installmodes/ubifs/ubifs_test.go
@@ -187,7 +187,7 @@ func TestUbifsInstallWithSuccessCompressed(t *testing.T) {
 
 	lam := &libarchivemock.LibArchiveMock{}
 
-	cpm := &copymock.CopierMock{}
+	cpm := &copymock.CopyMock{}
 	cpm.On("CopyToProcessStdin", fsm, lam, sourcePath, cmdline, compressed).Return(nil)
 
 	ufs := UbifsObject{
@@ -195,7 +195,7 @@ func TestUbifsInstallWithSuccessCompressed(t *testing.T) {
 		UbifsUtils:        uum,
 		LibArchiveBackend: lam,
 		FileSystemBackend: fsm,
-		Copier:            cpm,
+		CopyBackend:       cpm,
 	}
 	ufs.TargetType = "ubivolume"
 	ufs.Target = ubivolume
@@ -232,7 +232,7 @@ func TestUbifsInstallWithCopyToProcessStdinFailure(t *testing.T) {
 
 	lam := &libarchivemock.LibArchiveMock{}
 
-	cpm := &copymock.CopierMock{}
+	cpm := &copymock.CopyMock{}
 	cpm.On("CopyToProcessStdin", fsm, lam, sourcePath, cmdline, compressed).Return(fmt.Errorf("process error"))
 
 	ufs := UbifsObject{
@@ -240,7 +240,7 @@ func TestUbifsInstallWithCopyToProcessStdinFailure(t *testing.T) {
 		UbifsUtils:        uum,
 		LibArchiveBackend: lam,
 		FileSystemBackend: fsm,
-		Copier:            cpm,
+		CopyBackend:       cpm,
 	}
 	ufs.TargetType = "ubivolume"
 	ufs.Target = ubivolume

--- a/testsmocks/copymock/copy.go
+++ b/testsmocks/copymock/copy.go
@@ -18,21 +18,21 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type CopierMock struct {
+type CopyMock struct {
 	mock.Mock
 }
 
-func (cm *CopierMock) CopyFile(fsBackend afero.Fs, libarchiveBackend libarchive.API, sourcePath string, targetPath string, chunkSize int, skip int, seek int, count int, truncate bool, compressed bool) error {
+func (cm *CopyMock) CopyFile(fsBackend afero.Fs, libarchiveBackend libarchive.API, sourcePath string, targetPath string, chunkSize int, skip int, seek int, count int, truncate bool, compressed bool) error {
 	args := cm.Called(fsBackend, libarchiveBackend, sourcePath, targetPath, chunkSize, skip, seek, count, truncate, compressed)
 	return args.Error(0)
 }
 
-func (cm *CopierMock) Copy(wr io.Writer, rd io.Reader, timeout time.Duration, cancel <-chan bool, chunkSize int, skip int, count int, compressed bool) (bool, error) {
+func (cm *CopyMock) Copy(wr io.Writer, rd io.Reader, timeout time.Duration, cancel <-chan bool, chunkSize int, skip int, count int, compressed bool) (bool, error) {
 	args := cm.Called(wr, rd, timeout, cancel, chunkSize, skip, count, compressed)
 	return args.Bool(0), args.Error(1)
 }
 
-func (cm *CopierMock) CopyToProcessStdin(fsBackend afero.Fs, libarchiveBackend libarchive.API, sourcePath string, processCmdline string, compressed bool) error {
+func (cm *CopyMock) CopyToProcessStdin(fsBackend afero.Fs, libarchiveBackend libarchive.API, sourcePath string, processCmdline string, compressed bool) error {
 	args := cm.Called(fsBackend, libarchiveBackend, sourcePath, processCmdline, compressed)
 	return args.Error(0)
 }

--- a/updatehub/states_test.go
+++ b/updatehub/states_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/UpdateHub/updatehub/activeinactive"
 	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
-	"github.com/UpdateHub/updatehub/installmodes/copy"
+	"github.com/UpdateHub/updatehub/installmodes/imxkobs"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filemock"
@@ -1098,15 +1098,15 @@ func TestGetIndexOfObjectToBeInstalledWithActiveError(t *testing.T) {
 }
 
 func TestGetIndexOfObjectToBeInstalledWithMoreThanTwoObjects(t *testing.T) {
-	// declaration just to register the copy install mode
-	_ = &copy.CopyObject{}
+	// declaration just to register the imxkobs install mode
+	_ = &imxkobs.ImxKobsObject{}
 
 	activeInactiveJSONMetadataWithThreeObjects := `{
 	  "product-uid": "0123456789",
 	  "objects": [
 	    [
 	      {
-            "mode": "copy",
+            "mode": "imxkobs",
             "target": "/dev/xx1",
             "target-type": "device"
           }
@@ -1114,7 +1114,7 @@ func TestGetIndexOfObjectToBeInstalledWithMoreThanTwoObjects(t *testing.T) {
         ,
 	    [
 	      {
-            "mode": "copy",
+            "mode": "imxkobs",
             "target": "/dev/xx2",
             "target-type": "device"
           }
@@ -1122,7 +1122,7 @@ func TestGetIndexOfObjectToBeInstalledWithMoreThanTwoObjects(t *testing.T) {
         ,
 	    [
 	      {
-            "mode": "copy",
+            "mode": "imxkobs",
             "target": "/dev/xx3",
             "target-type": "device"
           }

--- a/updatehub/updatehub.go
+++ b/updatehub/updatehub.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/UpdateHub/updatehub/activeinactive"
 	"github.com/UpdateHub/updatehub/client"
+	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/utils"
 )
 
 type UpdateHub struct {
 	Controller
-	utils.Copier
+	CopyBackend copy.Interface `json:"-"`
 
 	settings                *Settings
 	Store                   afero.Fs
@@ -95,7 +96,7 @@ func (uh *UpdateHub) FetchUpdate(updateMetadata *metadata.UpdateMetadata, cancel
 		}
 		defer rd.Close()
 
-		_, err = uh.Copy(wr, rd, 30*time.Second, cancel, utils.ChunkSize, 0, -1, false)
+		_, err = uh.CopyBackend.Copy(wr, rd, 30*time.Second, cancel, utils.ChunkSize, 0, -1, false)
 		if err != nil {
 			return err
 		}

--- a/updatehub/updatehub_test.go
+++ b/updatehub/updatehub_test.go
@@ -152,9 +152,9 @@ func TestUpdateHubFetchUpdate(t *testing.T) {
 	target := &filemock.FileMock{}
 	target.On("Close").Return(nil)
 
-	cpm := &copymock.CopierMock{}
+	cpm := &copymock.CopyMock{}
 	cpm.On("Copy", target, source, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, nil)
-	uh.Copier = cpm
+	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
 	fsm.On("Create", path.Join(uh.settings.DownloadDir, objectUID)).Return(target, nil)
@@ -189,8 +189,8 @@ func TestUpdateHubFetchUpdateWithTargetFileError(t *testing.T) {
 	// setup filesystembackend
 	objectUID := updateMetadata.Objects[0][0].GetObjectMetadata().Sha256sum
 
-	cpm := &copymock.CopierMock{}
-	uh.Copier = cpm
+	cpm := &copymock.CopyMock{}
+	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
 	fsm.On("Create", path.Join(uh.settings.DownloadDir, objectUID)).Return((*filemock.FileMock)(nil), fmt.Errorf("create error"))
@@ -233,8 +233,8 @@ func TestUpdateHubFetchUpdateWithUpdaterError(t *testing.T) {
 	target := &filemock.FileMock{}
 	target.On("Close").Return(nil)
 
-	cpm := &copymock.CopierMock{}
-	uh.Copier = cpm
+	cpm := &copymock.CopyMock{}
+	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
 	fsm.On("Create", path.Join(uh.settings.DownloadDir, objectUID)).Return(target, nil)
@@ -281,9 +281,9 @@ func TestUpdateHubFetchUpdateWithCopyError(t *testing.T) {
 	target := &filemock.FileMock{}
 	target.On("Close").Return(nil)
 
-	cpm := &copymock.CopierMock{}
+	cpm := &copymock.CopyMock{}
 	cpm.On("Copy", target, source, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, fmt.Errorf("copy error"))
-	uh.Copier = cpm
+	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
 	fsm.On("Create", path.Join(uh.settings.DownloadDir, objectUID)).Return(target, nil)
@@ -356,10 +356,10 @@ func TestUpdateHubFetchUpdateWithActiveInactive(t *testing.T) {
 	// finish setup
 	uh.Updater = um
 
-	cpm := &copymock.CopierMock{}
+	cpm := &copymock.CopyMock{}
 	cpm.On("Copy", target1, source1, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, nil)
 	cpm.On("Copy", target2, source2, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, nil)
-	uh.Copier = cpm
+	uh.CopyBackend = cpm
 
 	err = uh.FetchUpdate(updateMetadata, nil)
 	assert.NoError(t, err)

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,0 +1,13 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package utils
+
+const (
+	ChunkSize = 128 * 1024
+)


### PR DESCRIPTION
This way the "updatehub-server" doesn't need to link with libarchive.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>