### PR TITLE
fixes default polling interval

### DIFF
--- a/updatehub/settings.go
+++ b/updatehub/settings.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultPollingInterval = 60 * 60 // one hour (in seconds)
+	defaultPollingInterval = time.Hour
 )
 
 type Settings struct {

--- a/updatehub/settings_test.go
+++ b/updatehub/settings_test.go
@@ -43,6 +43,31 @@ UpdateHubServerAddress=localhost
 MetadataPath=/tmp/metadata
 `
 
+func TestLoadSettingsDefaultValues(t *testing.T) {
+	s, err := LoadSettings(bytes.NewReader([]byte("")))
+	assert.NoError(t, err)
+
+	assert.Equal(t, time.Hour, s.PollingSettings.PollingInterval)
+	assert.Equal(t, true, s.PollingSettings.PollingEnabled)
+	assert.Equal(t, (time.Time{}).UTC(), s.PollingSettings.PersistentPollingSettings.LastPoll)
+	assert.Equal(t, (time.Time{}).UTC(), s.PollingSettings.PersistentPollingSettings.FirstPoll)
+	assert.Equal(t, time.Duration(0), s.PollingSettings.PersistentPollingSettings.ExtraPollingInterval)
+	assert.Equal(t, 0, s.PollingSettings.PersistentPollingSettings.PollingRetries)
+
+	assert.Equal(t, false, s.StorageSettings.ReadOnly)
+
+	assert.Equal(t, "/tmp", s.UpdateSettings.DownloadDir)
+	assert.Equal(t, true, s.UpdateSettings.AutoDownloadWhenAvailable)
+	assert.Equal(t, true, s.UpdateSettings.AutoInstallAfterDownload)
+	assert.Equal(t, true, s.UpdateSettings.AutoRebootAfterInstall)
+	assert.Equal(t, []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"}, s.UpdateSettings.SupportedInstallModes)
+
+	assert.Equal(t, false, s.NetworkSettings.DisableHTTPS)
+	assert.Equal(t, "", s.NetworkSettings.ServerAddress)
+
+	assert.Equal(t, "", s.FirmwareSettings.FirmwareMetadataPath)
+}
+
 func TestLoadSettings(t *testing.T) {
 	testCases := []struct {
 		name             string

--- a/updatehub/states.go
+++ b/updatehub/states.go
@@ -10,6 +10,7 @@ package updatehub
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -239,6 +240,11 @@ func (state *PollState) Handle(uh *UpdateHub) (State, bool) {
 	var nextState State
 
 	nextState = state
+
+	if state.interval <= 0 {
+		err := fmt.Errorf("Can't handle polling with invalid interval. It must be greater than zero")
+		return NewErrorState(nil, NewTransientError(err)), false
+	}
 
 	go func() {
 		ticks := state.ticksCount

--- a/updatehub/states_test.go
+++ b/updatehub/states_test.go
@@ -418,6 +418,22 @@ func TestPolling(t *testing.T) {
 	}
 }
 
+func TestPollingWithNoPollingInterval(t *testing.T) {
+	aim := &activeinactivemock.ActiveInactiveMock{}
+
+	uh, _ := newTestUpdateHub(nil, aim)
+
+	s := NewPollState(0)
+
+	nextState, _ := s.Handle(uh)
+
+	expectedState := NewErrorState(nil, NewTransientError(fmt.Errorf("Can't handle polling with invalid interval. It must be greater than zero")))
+
+	assert.Equal(t, expectedState, nextState)
+
+	aim.AssertExpectations(t)
+}
+
 func TestCancelPollState(t *testing.T) {
 	aim := &activeinactivemock.ActiveInactiveMock{}
 


### PR DESCRIPTION
It was configured to 3,6 microsseconds and it was leading to a
division by zero.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>