### PR TITLE
fixes "/update" HTTP API route

### DIFF
--- a/server/agent_backend.go
+++ b/server/agent_backend.go
@@ -66,7 +66,8 @@ func (ab *AgentBackend) status(w http.ResponseWriter, r *http.Request, p httprou
 
 func (ab *AgentBackend) update(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	go func() {
-		ab.UpdateHub.Controller.CheckUpdate(0)
+		s := updatehub.NewUpdateCheckState()
+		ab.UpdateHub.State.Cancel(true, s)
 	}()
 
 	w.WriteHeader(202)

--- a/server/agent_backend_test.go
+++ b/server/agent_backend_test.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path"
 	"reflect"
 	"testing"
@@ -26,7 +25,6 @@ import (
 	"github.com/UpdateHub/updatehub/updatehub"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -247,14 +245,7 @@ func TestUpdateRoute(t *testing.T) {
 
 	cm := &controllermock.ControllerMock{}
 
-	uh.Controller = cm
-	cm.On("CheckUpdate", 0).Run(func(args mock.Arguments) {
-		// this is on purpose, the response is supposed to be
-		// asynchronous and we should get the HTTP response before the
-		// sleep expires
-		time.Sleep(100 * time.Second)
-		os.Exit(1)
-	}).Return(&metadata.UpdateMetadata{}, 10*time.Second)
+	uh.State = updatehub.NewPollState(time.Hour)
 
 	r, err := http.Post(url+"/update", "application/json", nil)
 	assert.NoError(t, err)

--- a/updatehub/cancellable_state.go
+++ b/updatehub/cancellable_state.go
@@ -8,13 +8,28 @@
 
 package updatehub
 
+import "sync"
+
 type CancellableState struct {
 	BaseState
-	cancel chan bool
+	cancel         chan bool
+	nextState      State
+	nextStateMutex sync.Mutex
 }
 
-func (cs *CancellableState) Cancel(ok bool) bool {
+func (cs *CancellableState) NextState() State {
+	cs.nextStateMutex.Lock()
+	defer cs.nextStateMutex.Unlock()
+
+	return cs.nextState
+}
+
+func (cs *CancellableState) Cancel(ok bool, nextState State) bool {
+	cs.nextStateMutex.Lock()
+	defer cs.nextStateMutex.Unlock()
+
 	cs.cancel <- ok
+	cs.nextState = nextState
 	return ok
 }
 

--- a/updatehub/daemon_test.go
+++ b/updatehub/daemon_test.go
@@ -138,8 +138,8 @@ func (state *StateTest) ID() UpdateHubState {
 	return state.id
 }
 
-func (state *StateTest) Cancel(ok bool) bool {
-	return state.CancellableState.Cancel(ok)
+func (state *StateTest) Cancel(ok bool, nextState State) bool {
+	return state.CancellableState.Cancel(ok, nextState)
 }
 
 func (state *StateTest) Handle(uh *UpdateHub) (State, bool) {

--- a/updatehub/states_test.go
+++ b/updatehub/states_test.go
@@ -443,7 +443,7 @@ func TestCancelPollState(t *testing.T) {
 	poll.interval = 10 * time.Second
 
 	go func() {
-		assert.True(t, poll.Cancel(true))
+		assert.True(t, poll.Cancel(true, NewIdleState()))
 	}()
 
 	poll.Handle(uh)
@@ -510,10 +510,10 @@ func TestStateIdle(t *testing.T) {
 			uh.Settings = tc.settings
 
 			go func() {
-				uh.State.Cancel(false)
+				uh.State.Cancel(false, NewIdleState()) // write
 			}()
 
-			next, _ := uh.State.Handle(uh)
+			next, _ := uh.State.Handle(uh) // read
 			assert.IsType(t, tc.nextState, next)
 
 			aim.AssertExpectations(t)


### PR DESCRIPTION
By cancelling the current state and passing the next one as argument
to the Cancel method.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>