### PR TITLE
fixes status being reported every change

### DIFF
--- a/testsmocks/controllermock/controller.go
+++ b/testsmocks/controllermock/controller.go
@@ -33,8 +33,3 @@ func (cm *ControllerMock) InstallUpdate(updateMetadata *metadata.UpdateMetadata,
 	args := cm.Called(updateMetadata, progressChan)
 	return args.Error(0)
 }
-
-func (cm *ControllerMock) ReportCurrentState() error {
-	args := cm.Called()
-	return args.Error(0)
-}

--- a/testsmocks/controllermock/controller_test.go
+++ b/testsmocks/controllermock/controller_test.go
@@ -62,16 +62,3 @@ func TestInstallUpdate(t *testing.T) {
 
 	cm.AssertExpectations(t)
 }
-
-func TestReportCurrentState(t *testing.T) {
-	expectedError := fmt.Errorf("some error")
-
-	cm := &ControllerMock{}
-	cm.On("ReportCurrentState").Return(expectedError)
-
-	err := cm.ReportCurrentState()
-
-	assert.Equal(t, expectedError, err)
-
-	cm.AssertExpectations(t)
-}

--- a/testsmocks/reportermock/reporter.go
+++ b/testsmocks/reportermock/reporter.go
@@ -1,0 +1,23 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package reportermock
+
+import (
+	"github.com/UpdateHub/updatehub/client"
+	"github.com/stretchr/testify/mock"
+)
+
+type ReporterMock struct {
+	mock.Mock
+}
+
+func (rm *ReporterMock) ReportState(api client.ApiRequester, packageUID string, state string) error {
+	args := rm.Called(api, packageUID, state)
+	return args.Error(0)
+}

--- a/testsmocks/reportermock/reporter_test.go
+++ b/testsmocks/reportermock/reporter_test.go
@@ -1,0 +1,32 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package reportermock
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/UpdateHub/updatehub/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReportState(t *testing.T) {
+	rm := &ReporterMock{}
+	ar := client.NewApiClient("server_address").Request()
+
+	rm.On("ReportState", ar, "sha256sum1", "idle").Return(nil).Once()
+	err := rm.ReportState(ar, "sha256sum1", "idle")
+	assert.NoError(t, err)
+
+	rm.On("ReportState", ar, "sha256sum2", "downloading").Return(fmt.Errorf("report error")).Once()
+	err = rm.ReportState(ar, "sha256sum2", "downloading")
+	assert.EqualError(t, err, "report error")
+
+	rm.AssertExpectations(t)
+}


### PR DESCRIPTION
It should be reported only if the new status is different than the
previous status reported.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>