### PR TITLE
update "supported-hardware" syntax and behavior

### DIFF
--- a/client/update_test.go
+++ b/client/update_test.go
@@ -30,7 +30,6 @@ func TestCheckUpdateWithInvalidApiRequester(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -51,7 +50,6 @@ func TestCheckUpdateWithNewRequestError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -72,7 +70,6 @@ func TestCheckUpdateWithApiDoError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -105,7 +102,6 @@ func TestCheckUpdateWithExtraPollHeaderError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -138,7 +134,6 @@ func TestCheckUpdateWithResponseBodyReadError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -171,7 +166,6 @@ func TestCheckUpdateWithResponseBodyParseError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -204,7 +198,6 @@ func TestCheckUpdateWithInvalidStatusCode(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -237,7 +230,6 @@ func TestCheckUpdateWithNoUpdateAvailable(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -284,7 +276,6 @@ func TestCheckUpdateWithUpdateAvailable(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 
@@ -298,7 +289,7 @@ func TestCheckUpdateWithUpdateAvailable(t *testing.T) {
 	assert.Equal(t, "0123456789", um.ProductUID)
 	assert.Equal(t, "1.2", um.Version)
 	assert.Equal(t, []byte(expectedBody), um.RawBytes)
-	assert.Equal(t, 0, len(um.SupportedHardware))
+	assert.Equal(t, nil, um.SupportedHardware)
 
 	// Objects
 	assert.Equal(t, 1, len(um.Objects))

--- a/doc/agent-http.apib
+++ b/doc/agent-http.apib
@@ -67,8 +67,7 @@ the fields:
                         "attr1": "value1",
                         "attr2": "value2",
                     },
-                    "hardware": "board-name",
-                    "hardware-revision": "revA",
+                    "hardware": "board-name-revA",
                     "version": "1.2"
                 }
             }
@@ -174,14 +173,8 @@ as body.
                     ]
                 ],
                 "supported-hardware": [
-	                {
-                        "hardware": "hardware1",
-                        "hardware-revision": "revA"
-                    },
-	                {
-                        "hardware": "hardware2",
-                        "hardware-revision": "revB"
-                    }
+                    "hardware1-revA",
+                    "hardware2-revB"
 	            ]
             }
 

--- a/metadata/common_test.go
+++ b/metadata/common_test.go
@@ -12,8 +12,8 @@ const (
 	ValidJSONMetadata = `{
 	  "product-uid": "0123456789",
 	  "supported-hardware": [
-	    {"hardware": "hardware1", "hardware-revision": "revA"},
-	    {"hardware": "hardware2", "hardware-revision": "revB"}
+	    "hardware1-revA",
+	    "hardware2-revB"
 	  ],
 	  "objects": [
 	    [
@@ -57,6 +57,26 @@ const (
 	  "objects": [
 	    [
 	      { "mode": "test", "compressed": true }
+	    ]
+	  ]
+	}`
+
+	ValidJSONMetadataWithSupportedHardwareAny = `{
+	  "product-uid": "0123456789",
+	  "supported-hardware": "any",
+	  "objects": [
+	    [
+	      { "mode": "test" }
+	    ]
+	  ]
+	}`
+
+	ValidJSONMetadataWithUnknownSupportedHardwareFormat = `{
+	  "product-uid": "0123456789",
+	  "supported-hardware": { "hardware": "h1-revA" },
+	  "objects": [
+	    [
+	      { "mode": "test" }
 	    ]
 	  ]
 	}`

--- a/metadata/firmware_test.go
+++ b/metadata/firmware_test.go
@@ -27,14 +27,12 @@ func TestNewFirmwareMetadataWithSuccess(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name                  string
-		hardwareError         error
-		hardwareRevisionError error
-		versionError          error
+		name          string
+		hardwareError error
+		versionError  error
 	}{
 		{
 			"WithNoErrorOnAllOptionalFields",
-			nil,
 			nil,
 			nil,
 		},
@@ -47,23 +45,10 @@ func TestNewFirmwareMetadataWithSuccess(t *testing.T) {
 				Err:  syscall.ENOENT,
 			},
 			nil,
-			nil,
-		},
-
-		{
-			"WithHardwareRevisionScriptNotFound",
-			nil,
-			&os.PathError{
-				Op:   "open",
-				Path: path.Join(metadataPath, "hardware-revision"),
-				Err:  syscall.ENOENT,
-			},
-			nil,
 		},
 
 		{
 			"WithVersionScriptNotFound",
-			nil,
 			nil,
 			&os.PathError{
 				Op:   "open",
@@ -77,7 +62,6 @@ func TestNewFirmwareMetadataWithSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 			hardware := "board"
-			hardwareRevision := "revA"
 			version := "1.1"
 
 			expected := &FirmwareMetadata{
@@ -90,16 +74,14 @@ func TestNewFirmwareMetadataWithSuccess(t *testing.T) {
 					"attr1": "value1",
 					"attr2": "value2",
 				},
-				Hardware:         hardware,
-				HardwareRevision: hardwareRevision,
-				Version:          version,
+				Hardware: hardware,
+				Version:  version,
 			}
 
 			clm := &cmdlinemock.CmdLineExecuterMock{}
 
 			clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID), nil)
 			clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware), tc.hardwareError)
-			clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision), tc.hardwareRevisionError)
 			clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(version), tc.versionError)
 			clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key1")).Return([]byte("id1=value1"), nil)
 			clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key2")).Return([]byte("id2=value2"), nil)
@@ -137,7 +119,6 @@ func TestNewFirmwareMetadataWithSuccessWithNewLineCharacters(t *testing.T) {
 
 	productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	hardware := "board"
-	hardwareRevision := "revA"
 	version := "1.1"
 
 	expected := &FirmwareMetadata{
@@ -150,16 +131,14 @@ func TestNewFirmwareMetadataWithSuccessWithNewLineCharacters(t *testing.T) {
 			"attr1": "value1",
 			"attr2": "value2",
 		},
-		Hardware:         hardware,
-		HardwareRevision: hardwareRevision,
-		Version:          version,
+		Hardware: hardware,
+		Version:  version,
 	}
 
 	clm := &cmdlinemock.CmdLineExecuterMock{}
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID+"\n"), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware+"\n"), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision+"\n"), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(version+"\n"), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key1")).Return([]byte("id1=value1"+"\n"), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key2")).Return([]byte("id2=value2"+"\n"), nil)
@@ -192,14 +171,12 @@ func TestNewFirmwareMetadataWithNoDeviceIdentityScriptsFound(t *testing.T) {
 	metadataPath := "/"
 	productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	hardware := "board"
-	hardwareRevision := "revA"
 	version := "1.1"
 
 	clm := &cmdlinemock.CmdLineExecuterMock{}
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(version), nil)
 
 	store := afero.NewMemMapFs()
@@ -216,7 +193,6 @@ func TestNewFirmwareMetadataWithNoDeviceAttributesScriptsFound(t *testing.T) {
 	metadataPath := "/"
 	productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	hardware := "board"
-	hardwareRevision := "revA"
 	version := "1.1"
 
 	expected := &FirmwareMetadata{
@@ -227,7 +203,6 @@ func TestNewFirmwareMetadataWithNoDeviceAttributesScriptsFound(t *testing.T) {
 		},
 		DeviceAttributes: map[string]string{},
 		Hardware:         hardware,
-		HardwareRevision: hardwareRevision,
 		Version:          version,
 	}
 
@@ -235,7 +210,6 @@ func TestNewFirmwareMetadataWithNoDeviceAttributesScriptsFound(t *testing.T) {
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(version), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key1")).Return([]byte("id1=value1"), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key2")).Return([]byte("id2=value2"), nil)
@@ -295,25 +269,6 @@ func TestNewFirmwareMetadataWithHardwareError(t *testing.T) {
 	clm.AssertExpectations(t)
 }
 
-func TestNewFirmwareMetadataWithHardwareRevisionError(t *testing.T) {
-	metadataPath := "/"
-
-	clm := &cmdlinemock.CmdLineExecuterMock{}
-
-	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte("229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte("board"), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(""), fmt.Errorf("hardware-revision error"))
-
-	store := afero.NewMemMapFs()
-
-	firmwareMetadata, err := NewFirmwareMetadata(metadataPath, store, clm)
-
-	assert.EqualError(t, err, "hardware-revision error")
-	assert.Equal(t, ((*FirmwareMetadata)(nil)), firmwareMetadata)
-
-	clm.AssertExpectations(t)
-}
-
 func TestNewFirmwareMetadataWithVersionError(t *testing.T) {
 	metadataPath := "/"
 
@@ -321,7 +276,6 @@ func TestNewFirmwareMetadataWithVersionError(t *testing.T) {
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte("229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte("board"), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte("revA"), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(""), fmt.Errorf("version error"))
 
 	store := afero.NewMemMapFs()
@@ -338,14 +292,12 @@ func TestNewFirmwareMetadataWithDeviceIdentityError(t *testing.T) {
 	metadataPath := "/"
 	productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	hardware := "board"
-	hardwareRevision := "revA"
 	version := "1.1"
 
 	clm := &cmdlinemock.CmdLineExecuterMock{}
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(version), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key1")).Return([]byte(""), fmt.Errorf("device identity error"))
 
@@ -375,14 +327,12 @@ func TestNewFirmwareMetadataWithDeviceAttributesError(t *testing.T) {
 	metadataPath := "/"
 	productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	hardware := "board"
-	hardwareRevision := "revA"
 	version := "1.1"
 
 	clm := &cmdlinemock.CmdLineExecuterMock{}
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(version), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key1")).Return([]byte("id1=value1"), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key2")).Return([]byte("id2=value2"), nil)
@@ -412,29 +362,25 @@ func TestNewFirmwareMetadataWithDeviceAttributesError(t *testing.T) {
 
 func TestCheckSupportedHardware(t *testing.T) {
 	testCases := []struct {
-		name             string
-		hardware         string
-		hardwareRevision string
-		expectedErr      error
+		name        string
+		hardware    string
+		expectedErr error
 	}{
 		{
-			"WithNeitherHardwareNorHardwareRevisionOnFirmwareMetadata",
-			"",
+			"WithNoHardwareOnFirmwareMetadata",
 			"",
 			nil,
 		},
 
 		{
 			"WithMatch",
-			"hardware2",
-			"revB",
+			"hardware2-revB",
 			nil,
 		},
 
 		{
 			"WithNoMatch",
 			"hardware-value",
-			"hardware-revision-value",
 			fmt.Errorf("this hardware doesn't match the hardware supported by the update"),
 		},
 	}
@@ -446,7 +392,6 @@ func TestCheckSupportedHardware(t *testing.T) {
 				DeviceIdentity:   map[string]string{"id1": "id1-value"},
 				DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 				Hardware:         tc.hardware,
-				HardwareRevision: tc.hardwareRevision,
 				Version:          "version-value",
 			}
 
@@ -464,4 +409,50 @@ func TestCheckSupportedHardware(t *testing.T) {
 			assert.Equal(t, tc.expectedErr, err)
 		})
 	}
+}
+
+func TestCheckSupportedHardwareWithAnyString(t *testing.T) {
+	fm := &FirmwareMetadata{
+		ProductUID:       "productuid-value",
+		DeviceIdentity:   map[string]string{"id1": "id1-value"},
+		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
+		Hardware:         "hardware1-revA",
+		Version:          "version-value",
+	}
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return TestObject{} },
+	})
+	defer mode.Unregister()
+
+	um, err := NewUpdateMetadata([]byte(ValidJSONMetadataWithSupportedHardwareAny))
+	assert.NoError(t, err)
+
+	err = fm.CheckSupportedHardware(um)
+	assert.NoError(t, err)
+}
+
+func TestCheckSupportedHardwareWithUnknownFormat(t *testing.T) {
+	fm := &FirmwareMetadata{
+		ProductUID:       "productuid-value",
+		DeviceIdentity:   map[string]string{"id1": "id1-value"},
+		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
+		Hardware:         "hardware1-revA",
+		Version:          "version-value",
+	}
+
+	mode := installmodes.RegisterInstallMode(installmodes.InstallMode{
+		Name:              "test",
+		CheckRequirements: func() error { return nil },
+		GetObject:         func() interface{} { return TestObject{} },
+	})
+	defer mode.Unregister()
+
+	um, err := NewUpdateMetadata([]byte(ValidJSONMetadataWithUnknownSupportedHardwareFormat))
+	assert.NoError(t, err)
+
+	err = fm.CheckSupportedHardware(um)
+	assert.EqualError(t, err, "unknown supported hardware format in the update metadata")
 }

--- a/metadata/update.go
+++ b/metadata/update.go
@@ -14,16 +14,11 @@ import (
 	"github.com/UpdateHub/updatehub/utils"
 )
 
-type Hardware struct {
-	Hardware         string `json:"hardware"`
-	HardwareRevision string `json:"hardware-revision"`
-}
-
 type UpdateMetadata struct {
-	ProductUID        string     `json:"product-uid"`
-	Version           string     `json:"version"`
-	Objects           [][]Object `json:"-"`
-	SupportedHardware []Hardware `json:"supported-hardware"`
+	ProductUID        string      `json:"product-uid"`
+	Version           string      `json:"version"`
+	Objects           [][]Object  `json:"-"`
+	SupportedHardware interface{} `json:"supported-hardware"`
 	RawBytes          []byte
 }
 

--- a/server/agent_backend_test.go
+++ b/server/agent_backend_test.go
@@ -181,7 +181,6 @@ func setup(t *testing.T) (*updatehub.UpdateHub, string, *cmdlinemock.CmdLineExec
 	// setup mock
 	productUID := "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	hardware := "board"
-	hardwareRevision := "revA"
 	firmwareVersion := "1.1"
 	agentVersion := "0.6.90-7-ga456673"
 	buildTime := "2017-06-01 17:24 UTC"
@@ -190,7 +189,6 @@ func setup(t *testing.T) (*updatehub.UpdateHub, string, *cmdlinemock.CmdLineExec
 
 	clm.On("Execute", path.Join(metadataPath, "product-uid")).Return([]byte(productUID), nil)
 	clm.On("Execute", path.Join(metadataPath, "hardware")).Return([]byte(hardware), nil)
-	clm.On("Execute", path.Join(metadataPath, "hardware-revision")).Return([]byte(hardwareRevision), nil)
 	clm.On("Execute", path.Join(metadataPath, "version")).Return([]byte(firmwareVersion), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key1")).Return([]byte("id1=value1"), nil)
 	clm.On("Execute", path.Join(metadataPath, "/device-identity.d/key2")).Return([]byte("id2=value2"), nil)

--- a/server/server_backend_test.go
+++ b/server/server_backend_test.go
@@ -26,8 +26,8 @@ const (
 	ValidJSONMetadata = `{
           "product-uid": "0123456789",
           "supported-hardware": [
-            {"hardware": "hardware1", "hardware-revision": "revA"},
-            {"hardware": "hardware2", "hardware-revision": "revB"}
+            "hardware1-revA",
+            "hardware2-revB"
           ],
           "objects": [
             [

--- a/updatehub/updatehub_test.go
+++ b/updatehub/updatehub_test.go
@@ -386,7 +386,6 @@ func TestUpdateHubFetchUpdate(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 	uh.FirmwareMetadata = *fm
@@ -529,7 +528,6 @@ func TestUpdateHubFetchUpdateWithUpdaterError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 	uh.FirmwareMetadata = *fm
@@ -591,7 +589,6 @@ func TestUpdateHubFetchUpdateWithCopyError(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 	uh.FirmwareMetadata = *fm
@@ -658,7 +655,6 @@ func TestUpdateHubFetchUpdateWithActiveInactive(t *testing.T) {
 		DeviceIdentity:   map[string]string{"id1": "id1-value"},
 		DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 		Hardware:         "",
-		HardwareRevision: "",
 		Version:          "version-value",
 	}
 	uh.FirmwareMetadata = *fm
@@ -787,7 +783,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -839,7 +834,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "hardware-value",
-					HardwareRevision: "hardware-revision-value",
 					Version:          "version-value",
 				}
 
@@ -852,7 +846,7 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 				return data
 			}(),
 			validUpdateMetadata,
-			fmt.Errorf("this hardware doesn't match the hardware supported by the update"),
+			fmt.Errorf("unknown supported hardware format in the update metadata"),
 			[]int(nil),
 		},
 		{
@@ -865,7 +859,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -914,7 +907,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -948,7 +940,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -991,7 +982,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -1025,7 +1015,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -1063,7 +1052,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -1101,7 +1089,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -1139,7 +1126,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 
@@ -1168,7 +1154,6 @@ func TestUpdateHubInstallUpdate(t *testing.T) {
 					DeviceIdentity:   map[string]string{"id1": "id1-value"},
 					DeviceAttributes: map[string]string{"attr1": "attr1-value"},
 					Hardware:         "",
-					HardwareRevision: "",
 					Version:          "version-value",
 				}
 


### PR DESCRIPTION
- on update metadata, "hardware-revision" doesn't exist anymore,
  instead, the "hardware" string will include the revision too
- "supported-hardware" it is an array os strings instead of an array
  of objects and each string corresponds to a hardware
- corner-case: when "supported-hardware" is just the string "any"
  instead of an array of strings, any hardware will be supported

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>