### PR TITLE
make paths indirections of system settings

### DIFF
--- a/cmd/updatehub/constants.go
+++ b/cmd/updatehub/constants.go
@@ -11,9 +11,4 @@ package main
 const (
 	// The system settings are the settings configured in the client-side and will be read-only
 	systemSettingsPath = "/etc/updatehub.conf"
-	// The runtime settings are the settings that may can change during the execution of UpdateHub
-	// These settings are persisted to keep the behaviour across of device's reboot
-	runtimeSettingsPath = "/var/lib/updatehub.conf"
-	// The path on which will be located the scripts that provide the firmware metadata
-	firmwareMetadataDirPath = "/usr/share/updatehub"
 )

--- a/updatehub/settings_test.go
+++ b/updatehub/settings_test.go
@@ -104,7 +104,7 @@ func TestLoadSettingsDefaultValues(t *testing.T) {
 
 	assert.Equal(t, "api.updatehub.io", s.NetworkSettings.ServerAddress)
 
-	assert.Equal(t, "", s.FirmwareSettings.FirmwareMetadataPath)
+	assert.Equal(t, "/usr/share/updatehub", s.FirmwareSettings.FirmwareMetadataPath)
 }
 
 func TestLoadSettings(t *testing.T) {
@@ -129,7 +129,8 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				StorageSettings: StorageSettings{
-					ReadOnly: false,
+					ReadOnly:            false,
+					RuntimeSettingsPath: "/var/lib/updatehub.conf",
 				},
 
 				UpdateSettings: UpdateSettings{
@@ -145,7 +146,7 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				FirmwareSettings: FirmwareSettings{
-					FirmwareMetadataPath: "",
+					FirmwareMetadataPath: "/usr/share/updatehub",
 				},
 			},
 		},
@@ -166,7 +167,8 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				StorageSettings: StorageSettings{
-					ReadOnly: true,
+					ReadOnly:            true,
+					RuntimeSettingsPath: "/var/lib/updatehub.conf",
 				},
 
 				UpdateSettings: UpdateSettings{


### PR DESCRIPTION
This is applied on the runtime settings path and the firmware
metadata path.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>