### PR TITLE
updatehub/settings.go: creation of the "ManualMode" settings flag

### DIFF
--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/OSSystems/pkg/log"
 	"github.com/imdario/mergo"
@@ -138,11 +139,16 @@ func main() {
 
 	uh.StartPolling()
 
-	d := updatehub.NewDaemon(uh)
-
 	log.Info("UpdateHub Agent started")
 
-	os.Exit(d.Run())
+	if !uh.Settings.ManualMode {
+		d := updatehub.NewDaemon(uh)
+		os.Exit(d.Run())
+	} else {
+		for {
+			time.Sleep(time.Second)
+		}
+	}
 }
 
 func loadSettings(fs afero.Fs, structToSaveOn *updatehub.Settings, pathToLoadFrom string) error {

--- a/server/server_backend_test.go
+++ b/server/server_backend_test.go
@@ -275,10 +275,11 @@ func TestProcessDirectoryWithExactlyOneUhuPkg(t *testing.T) {
 
 	tarballPath, err := generateUhupkg(memFs, true)
 	assert.NoError(t, err)
+	defer memFs.Remove(tarballPath)
 
 	testPath, err := afero.TempDir(memFs, "", "server-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(testPath)
+	defer memFs.RemoveAll(testPath)
 
 	pkgpath := path.Join(testPath, "name.uhupkg")
 
@@ -423,10 +424,11 @@ func TestGetObjectRouteWithUhupkg(t *testing.T) {
 	// setup filesystem
 	tarballPath, err := generateUhupkg(memFs, true)
 	assert.NoError(t, err)
+	defer memFs.Remove(tarballPath)
 
 	testPath, err := afero.TempDir(memFs, "", "server-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(testPath)
+	defer memFs.RemoveAll(testPath)
 
 	pkgpath := path.Join(testPath, "name.uhupkg")
 
@@ -503,10 +505,11 @@ func TestGetObjectRouteWithUhupkgExtractError(t *testing.T) {
 	// setup filesystem
 	tarballPath, err := generateUhupkg(memFs, false) // with error
 	assert.NoError(t, err)
+	defer memFs.Remove(tarballPath)
 
 	testPath, err := afero.TempDir(memFs, "", "server-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(testPath)
+	defer memFs.RemoveAll(testPath)
 
 	pkgpath := path.Join(testPath, "name.uhupkg")
 
@@ -634,7 +637,6 @@ func generateUhupkg(fsBackend afero.Fs, valid bool) (string, error) {
 		}
 
 		f, err := zw.Create(file.Name)
-
 		if err != nil {
 			return "", err
 		}

--- a/testsmocks/responsewritermock/responsewriter.go
+++ b/testsmocks/responsewritermock/responsewriter.go
@@ -1,0 +1,34 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package responsewritermock
+
+import (
+	"net/http"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type ResponseWriterMock struct {
+	mock.Mock
+	http.ResponseWriter
+}
+
+func (rwm *ResponseWriterMock) Header() http.Header {
+	args := rwm.Called()
+	return args.Get(0).(http.Header)
+}
+
+func (rwm *ResponseWriterMock) Write(b []byte) (int, error) {
+	args := rwm.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (rwm *ResponseWriterMock) WriteHeader(h int) {
+	rwm.Called(h)
+}

--- a/testsmocks/responsewritermock/responsewriter_test.go
+++ b/testsmocks/responsewritermock/responsewriter_test.go
@@ -1,0 +1,55 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package responsewritermock
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeader(t *testing.T) {
+	rwm := &ResponseWriterMock{}
+
+	expected := http.Header{}
+
+	rwm.On("Header").Return(expected)
+	h := rwm.Header()
+
+	assert.Equal(t, expected, h)
+
+	rwm.AssertExpectations(t)
+}
+
+func TestWrite(t *testing.T) {
+	buffer := []byte("content")
+
+	rwm := &ResponseWriterMock{}
+
+	expectedError := fmt.Errorf("some error")
+
+	rwm.On("Write", buffer).Return(0, expectedError)
+	i, err := rwm.Write(buffer)
+
+	assert.Equal(t, expectedError, err)
+	assert.Equal(t, 0, i)
+
+	rwm.AssertExpectations(t)
+}
+
+func TestWriteHeader(t *testing.T) {
+	rwm := &ResponseWriterMock{}
+
+	rwm.On("WriteHeader", 200).Return()
+	rwm.WriteHeader(200)
+
+	rwm.AssertExpectations(t)
+}

--- a/updatehub/daemon.go
+++ b/updatehub/daemon.go
@@ -25,19 +25,10 @@ func (d *Daemon) Stop() {
 
 func (d *Daemon) Run() int {
 	for {
-		d.uh.ReportCurrentState()
+		nextState := d.uh.ProcessCurrentState()
 
-		state, cancel := d.uh.State.Handle(d.uh)
-
-		cs, ok := d.uh.State.(*CancellableState)
-		if cancel && ok {
-			d.uh.State = cs.NextState()
-		} else {
-			d.uh.State = state
-		}
-
-		if d.stop || state.ID() == UpdateHubStateExit {
-			if finalState, _ := state.(*ExitState); finalState != nil {
+		if d.stop || nextState.ID() == UpdateHubStateExit {
+			if finalState, _ := nextState.(*ExitState); finalState != nil {
 				return finalState.exitCode
 			}
 

--- a/updatehub/daemon_test.go
+++ b/updatehub/daemon_test.go
@@ -40,7 +40,7 @@ func TestDaemonRun(t *testing.T) {
 
 	state := NewStateTest(d)
 
-	uh.State = state
+	uh.SetState(state)
 
 	d.Run()
 
@@ -75,15 +75,15 @@ func TestDaemonExitStateStop(t *testing.T) {
 
 	d := NewDaemon(uh)
 
-	uh.State = NewErrorState(nil, NewFatalError(errors.New("err_msg")))
+	uh.SetState(NewErrorState(nil, NewFatalError(errors.New("err_msg"))))
 
 	assert.Equal(t, 1, d.Run())
 
-	assert.IsType(t, &ExitState{}, uh.State)
+	assert.IsType(t, &ExitState{}, uh.GetState())
 	assert.Equal(t, 1, len(hook.Entries))
 	assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
 	assert.Equal(t, "fatal error: err_msg", hook.LastEntry().Message)
-	assert.Equal(t, 1, uh.State.(*ExitState).exitCode)
+	assert.Equal(t, 1, uh.GetState().(*ExitState).exitCode)
 
 	aim.AssertExpectations(t)
 	rm.AssertExpectations(t)

--- a/updatehub/idle_state_test.go
+++ b/updatehub/idle_state_test.go
@@ -73,10 +73,10 @@ func TestStateIdle(t *testing.T) {
 			uh.Settings = tc.settings
 
 			go func() {
-				uh.State.Cancel(false, NewIdleState()) // write
+				uh.Cancel(NewIdleState()) // write
 			}()
 
-			next, _ := uh.State.Handle(uh) // read
+			next, _ := uh.GetState().Handle(uh) // read
 			assert.IsType(t, tc.nextState, next)
 
 			aim.AssertExpectations(t)
@@ -84,7 +84,7 @@ func TestStateIdle(t *testing.T) {
 			expectedMap := map[string]interface{}{}
 			expectedMap["status"] = "idle"
 
-			assert.Equal(t, expectedMap, uh.State.ToMap())
+			assert.Equal(t, expectedMap, uh.GetState().ToMap())
 		})
 	}
 }

--- a/updatehub/installing_state_test.go
+++ b/updatehub/installing_state_test.go
@@ -118,7 +118,7 @@ func TestStateInstallingWithUpdateMetadataAlreadyInstalled(t *testing.T) {
 	expectedState := NewWaitingForRebootState(m)
 	assert.Equal(t, expectedState, nextState)
 
-	uh.State = nextState
+	uh.SetState(nextState)
 
 	aim.AssertExpectations(t)
 	om.AssertExpectations(t)

--- a/updatehub/poll_state_test.go
+++ b/updatehub/poll_state_test.go
@@ -70,9 +70,9 @@ func TestPollingRetries(t *testing.T) {
 	uh.Settings.PollingInterval = time.Second
 	uh.Settings.LastPoll = time.Now()
 
-	uh.State = NewPollState(uh.Settings.PollingInterval)
+	uh.SetState(NewPollState(uh.Settings.PollingInterval))
 
-	next, _ := uh.State.Handle(uh)
+	next, _ := uh.GetState().Handle(uh)
 	assert.IsType(t, &UpdateProbeState{}, next)
 
 	for i := 1; i < 3; i++ {
@@ -158,7 +158,7 @@ func TestPolling(t *testing.T) {
 
 			uh.StartPolling()
 
-			poll := uh.State
+			poll := uh.GetState()
 			assert.IsType(t, &PollState{}, poll)
 
 			poll.Handle(uh)

--- a/updatehub/settings.go
+++ b/updatehub/settings.go
@@ -41,11 +41,9 @@ var DefaultSettings = Settings{
 	},
 
 	UpdateSettings: UpdateSettings{
-		DownloadDir:               "/tmp",
-		AutoDownloadWhenAvailable: true,
-		AutoInstallAfterDownload:  true,
-		AutoRebootAfterInstall:    true,
-		SupportedInstallModes:     []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+		DownloadDir:           "/tmp",
+		SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+		ManualMode:            false,
 	},
 
 	NetworkSettings: NetworkSettings{
@@ -88,11 +86,9 @@ type StorageSettings struct {
 }
 
 type UpdateSettings struct {
-	DownloadDir               string   `ini:"DownloadDir" json:"download-dir"`
-	AutoDownloadWhenAvailable bool     `ini:"AutoDownloadWhenAvailable" json:"auto-download-when-available"`
-	AutoInstallAfterDownload  bool     `ini:"AutoInstallAfterDownload" json:"auto-install-after-download"`
-	AutoRebootAfterInstall    bool     `ini:"AutoRebootAfterInstall" json:"auto-reboot-after-install"`
-	SupportedInstallModes     []string `ini:"SupportedInstallModes" json:"supported-install-modes"`
+	DownloadDir           string   `ini:"DownloadDir" json:"download-dir"`
+	SupportedInstallModes []string `ini:"SupportedInstallModes" json:"supported-install-modes"`
+	ManualMode            bool     `ini:"ManualMode" json:"manual-mode"`
 }
 
 type NetworkSettings struct {

--- a/updatehub/settings_test.go
+++ b/updatehub/settings_test.go
@@ -31,9 +31,7 @@ ReadOnly=true
 
 [Update]
 DownloadDir=/tmp/download
-AutoDownloadWhenAvailable=false
-AutoInstallAfterDownload=false
-AutoRebootAfterInstall=false
+ManualMode=true
 SupportedInstallModes=mode1,mode2
 
 [Network]
@@ -61,11 +59,9 @@ func TestToString(t *testing.T) {
 		},
 
 		UpdateSettings: UpdateSettings{
-			DownloadDir:               "/tmp",
-			AutoDownloadWhenAvailable: true,
-			AutoInstallAfterDownload:  true,
-			AutoRebootAfterInstall:    true,
-			SupportedInstallModes:     []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+			DownloadDir:           "/tmp",
+			ManualMode:            true,
+			SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
 		},
 
 		NetworkSettings: NetworkSettings{
@@ -97,9 +93,7 @@ func TestLoadSettingsDefaultValues(t *testing.T) {
 	assert.Equal(t, false, s.StorageSettings.ReadOnly)
 
 	assert.Equal(t, "/tmp", s.UpdateSettings.DownloadDir)
-	assert.Equal(t, true, s.UpdateSettings.AutoDownloadWhenAvailable)
-	assert.Equal(t, true, s.UpdateSettings.AutoInstallAfterDownload)
-	assert.Equal(t, true, s.UpdateSettings.AutoRebootAfterInstall)
+	assert.Equal(t, false, s.UpdateSettings.ManualMode)
 	assert.Equal(t, []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"}, s.UpdateSettings.SupportedInstallModes)
 
 	assert.Equal(t, "api.updatehub.io", s.NetworkSettings.ServerAddress)
@@ -134,11 +128,9 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				UpdateSettings: UpdateSettings{
-					DownloadDir:               "/tmp",
-					AutoDownloadWhenAvailable: true,
-					AutoInstallAfterDownload:  true,
-					AutoRebootAfterInstall:    true,
-					SupportedInstallModes:     []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+					DownloadDir:           "/tmp",
+					ManualMode:            false,
+					SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
 				},
 
 				NetworkSettings: NetworkSettings{
@@ -172,11 +164,9 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				UpdateSettings: UpdateSettings{
-					DownloadDir:               "/tmp/download",
-					AutoDownloadWhenAvailable: false,
-					AutoInstallAfterDownload:  false,
-					AutoRebootAfterInstall:    false,
-					SupportedInstallModes:     []string{"mode1", "mode2"},
+					DownloadDir:           "/tmp/download",
+					ManualMode:            true,
+					SupportedInstallModes: []string{"mode1", "mode2"},
 				},
 
 				NetworkSettings: NetworkSettings{

--- a/updatehub/updatehub_test.go
+++ b/updatehub/updatehub_test.go
@@ -154,7 +154,7 @@ func TestNewUpdateHub(t *testing.T) {
 	assert.Equal(t, &activeinactive.DefaultImpl{CmdLineExecuter: &utils.CmdLine{}}, uh.ActiveInactiveBackend)
 	assert.Equal(t, gitversion, uh.Version)
 	assert.Equal(t, buildtime, uh.BuildTime)
-	assert.Equal(t, initialState, uh.State)
+	assert.Equal(t, initialState, uh.GetState())
 	assert.Equal(t, client.NewUpdateClient(), uh.Updater)
 	assert.Equal(t, time.Minute, uh.TimeStep)
 	assert.Equal(t, memFs, uh.Store)
@@ -1549,9 +1549,9 @@ func TestStartPolling(t *testing.T) {
 			uh.Settings.LastPoll = tc.lastPoll
 
 			uh.StartPolling()
-			assert.IsType(t, tc.expectedState, uh.State)
+			assert.IsType(t, tc.expectedState, uh.GetState())
 
-			tc.subTest(t, uh, uh.State)
+			tc.subTest(t, uh, uh.GetState())
 
 			aim.AssertExpectations(t)
 		})
@@ -1582,7 +1582,7 @@ func newTestUpdateHub(state State, aii activeinactive.Interface) (*UpdateHub, er
 	fs := afero.NewMemMapFs()
 	uh := &UpdateHub{
 		Store:    fs,
-		State:    state,
+		state:    state,
 		TimeStep: time.Second,
 		API:      client.NewApiClient("localhost"),
 		ActiveInactiveBackend: aii,

--- a/updatehub/updateprobe_state.go
+++ b/updatehub/updateprobe_state.go
@@ -8,7 +8,9 @@
 
 package updatehub
 
-import "time"
+import (
+	"time"
+)
 
 // UpdateProbeState is the State interface implementation for the UpdateHubStateUpdateProbe
 type UpdateProbeState struct {

--- a/updatehub/updateprobe_state_test.go
+++ b/updatehub/updateprobe_state_test.go
@@ -78,7 +78,7 @@ func TestStateUpdateProbe(t *testing.T) {
 			uh.Controller = tc.controller
 			uh.Settings = tc.settings
 
-			next, _ := uh.State.Handle(uh)
+			next, _ := uh.GetState().Handle(uh)
 
 			assert.IsType(t, tc.nextState, next)
 
@@ -115,7 +115,7 @@ func TestStateUpdateProbeWithUpdateAvailableButAlreadyInstalled(t *testing.T) {
 	uh.Controller = cm
 	uh.Settings = &Settings{}
 
-	next, _ := uh.State.Handle(uh)
+	next, _ := uh.GetState().Handle(uh)
 
 	assert.IsType(t, &WaitingForRebootState{}, next)
 


### PR DESCRIPTION
When this flag is enabled:

- the automatic polling is NOT started
- the HTTP API is complete

When this flag is disabled (default):

- the automatic polling IS started
- the HTTP API is NOT complete

- only the following routes WORK:
-- "/info"
-- "/status"
-- "/update/metadata"
-- "/update/probe"
-- "/log"

- only the following routes DO NOT work:
-- "/update"
-- "/update/download"
-- "/update/download/abort"
-- "/update/install"
-- "/reboot"

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>