### PR TITLE
HTTP API refactoring

### DIFF
--- a/cmd/updatehub/constants.go
+++ b/cmd/updatehub/constants.go
@@ -11,4 +11,15 @@ package main
 const (
 	// The system settings are the settings configured in the client-side and will be read-only
 	systemSettingsPath = "/etc/updatehub.conf"
+
+	// The state change callback is executed twice each state
+	// change. Once before the state handling and once after. Ex.:
+	// <stateChangeCallbackPath> enter downloading
+	// <stateChangeCallbackPath> leave downloading
+	stateChangeCallbackPath = "/usr/share/updatehub/state-change-callback"
+
+	// The error callback is executed whenever a error state is
+	// handled. Ex.:
+	// <errorCallbackPath> 'error_message'
+	errorCallbackPath = "/usr/share/updatehub/error-callback"
 )

--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -96,6 +96,8 @@ func main() {
 	log.Info("    system settings path: ", systemSettingsPath)
 	log.Info("    runtime settings path: ", settings.RuntimeSettingsPath)
 	log.Info("    firmware metadata path: ", settings.FirmwareMetadataPath)
+	log.Info("    state change callback path: ", stateChangeCallbackPath)
+	log.Info("    error callback path: ", errorCallbackPath)
 
 	log.Debug("settings:\n", settings.ToString())
 
@@ -107,7 +109,7 @@ func main() {
 
 	osFs.MkdirAll(settings.DownloadDir, 0755)
 
-	uh := updatehub.NewUpdateHub(gitversion, buildtime, osFs, *fm, updatehub.NewIdleState(), settings)
+	uh := updatehub.NewUpdateHub(gitversion, buildtime, stateChangeCallbackPath, errorCallbackPath, osFs, *fm, updatehub.NewIdleState(), settings)
 
 	backend, err := server.NewAgentBackend(uh)
 	if err != nil {
@@ -138,10 +140,9 @@ func main() {
 
 	uh.StartPolling()
 
-	d := updatehub.NewDaemon(uh)
-
 	log.Info("UpdateHub Agent started")
 
+	d := updatehub.NewDaemon(uh)
 	os.Exit(d.Run())
 }
 

--- a/doc/agent-http.apib
+++ b/doc/agent-http.apib
@@ -76,114 +76,7 @@ the fields:
 
 
 
-## Group Status
-
-### status [GET /status]
-
-Get the agent current internal status.
-
-Reportable states:
-- "idle"
-- "downloading"
-- "installing"
-- "installed"
-- "waiting-for-reboot"
-- "error"
-
-Returns HTTP 200 and a json object as body. The object contents
-depends on the state returned. The common field among them is:
-- status: the current internal status
-
-For "status" == "error":
-- error: contains the error message
-
-For "status" == "downloading" or "status" == "installing":
-- progress: contains the finished percetage of the action
-
-+ Response 200 (application/json)
-
-    + Body
-
-            {
-                "status":"downloading",
-                "progress": 25
-            }
-
-
-
-
-
 ## Group Update
-
-### update [POST /update]
-
-This route fires the complete update procedure, which is the following:
-- trigger the "/update/probe" route
-- if there is an update available and the configuration file is set to
-  automatically download the update after the probe, then trigger the
-  "/update/download" route
-- if the configuration file is set to automatically install after a
-  download, then trigger the "/update/install" route
-- if the configuration file is set to automatically reboot after an
-  installation, then trigger the "/reboot" route
-
-This is the same procedure that is done in the automatic polling logic.
-
-Always returns HTTP 202 and a fixed message on a json object as
-body.
-
-+ Response 202 (application/json)
-
-    + Body
-
-            {
-                "message": "request accepted, update procedure fired"
-            }
-
-### metadata [GET /update/metadata]
-
-On success, returns HTTP 202 with the update metadata as json body. On
-failure, returns HTTP 400 and the error message inside a json object
-as body.
-
-+ Response 200 (application/json)
-
-    + Body
-
-            {
-                "product-uid": "",
-                "objects": [
-                    [
-                        {
-                            "mode": "copy",
-                            "sha256sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                            "target": "/dev/xx1",
-                            "target-type": "device"
-                        }
-                    ]
-                    ,
-                    [
-                        {
-                            "mode": "copy",
-                            "sha256sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                            "target": "/dev/xx2",
-                            "target-type": "device"
-                        }
-                    ]
-                ],
-                "supported-hardware": [
-                    "hardware1-revA",
-                    "hardware2-revB"
-	            ]
-            }
-
-+ Response 400 (application/json)
-
-    + Body
-
-            {
-                "error": "update metadata hasn't been downloaded yet"
-            }
 
 ### probe [POST /update/probe]
 
@@ -200,28 +93,6 @@ the caller should try the request again 'n' seconds from now, where
             {
                 "update-available": false,
                 "try-again-in": 3600
-            }
-
-### download [POST /update/download]
-
-Download the update objects. On success, returns HTTP 202 and a empty
-json object as body. On failure, returns HTTP 400 and the error
-message inside a json object as body.
-
-+ Response 202 (application/json)
-
-    + Body
-
-            {
-                "message": "request accepted, downloading update objects"
-            }
-
-+ Response 400 (application/json)
-
-    + Body
-
-            {
-                "error": "update metadata hasn't been downloaded yet"
             }
 
 ### abort download [POST /update/download/abort]
@@ -246,54 +117,6 @@ returns HTTP 400 and the error message inside a json object as body.
                 "error": "there is no download to be aborted"
             }
 
-### install [POST /update/install]
-
-Install the update objects. On success, returns HTTP 202 and a empty
-json object as body. On failure, returns HTTP 400 and the error
-message inside a json object as body.
-
-+ Response 202 (application/json)
-
-    + Body
-
-            {
-                "message": "request accepted, installing update"
-            }
-
-+ Response 400 (application/json)
-
-    + Body
-
-            {
-                "error": "update objects have not been downloaded yet"
-            }
-
-
-
-
-
-## Group Reboot
-
-### reboot [POST /reboot]
-
-Sync the filesystem and reboot the device. It may not respond since it
-will reboot the device, but when it does, the response is the below.
-
-+ Response 202 (application/json)
-
-    + Body
-
-            {
-                "message": "request accepted, rebooting the device"
-            }
-            
-+ Response 400 (application/json)
-
-    + Body
-
-            {
-                "error": "permission denied"
-            }
 
 
 

--- a/server/server_backend_test.go
+++ b/server/server_backend_test.go
@@ -275,10 +275,11 @@ func TestProcessDirectoryWithExactlyOneUhuPkg(t *testing.T) {
 
 	tarballPath, err := generateUhupkg(memFs, true)
 	assert.NoError(t, err)
+	defer memFs.Remove(tarballPath)
 
 	testPath, err := afero.TempDir(memFs, "", "server-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(testPath)
+	defer memFs.RemoveAll(testPath)
 
 	pkgpath := path.Join(testPath, "name.uhupkg")
 
@@ -423,10 +424,11 @@ func TestGetObjectRouteWithUhupkg(t *testing.T) {
 	// setup filesystem
 	tarballPath, err := generateUhupkg(memFs, true)
 	assert.NoError(t, err)
+	defer memFs.Remove(tarballPath)
 
 	testPath, err := afero.TempDir(memFs, "", "server-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(testPath)
+	defer memFs.RemoveAll(testPath)
 
 	pkgpath := path.Join(testPath, "name.uhupkg")
 
@@ -503,10 +505,11 @@ func TestGetObjectRouteWithUhupkgExtractError(t *testing.T) {
 	// setup filesystem
 	tarballPath, err := generateUhupkg(memFs, false) // with error
 	assert.NoError(t, err)
+	defer memFs.Remove(tarballPath)
 
 	testPath, err := afero.TempDir(memFs, "", "server-test")
 	assert.NoError(t, err)
-	defer os.RemoveAll(testPath)
+	defer memFs.RemoveAll(testPath)
 
 	pkgpath := path.Join(testPath, "name.uhupkg")
 
@@ -634,7 +637,6 @@ func generateUhupkg(fsBackend afero.Fs, valid bool) (string, error) {
 		}
 
 		f, err := zw.Create(file.Name)
-
 		if err != nil {
 			return "", err
 		}

--- a/testsmocks/responsewritermock/responsewriter.go
+++ b/testsmocks/responsewritermock/responsewriter.go
@@ -1,0 +1,34 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package responsewritermock
+
+import (
+	"net/http"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type ResponseWriterMock struct {
+	mock.Mock
+	http.ResponseWriter
+}
+
+func (rwm *ResponseWriterMock) Header() http.Header {
+	args := rwm.Called()
+	return args.Get(0).(http.Header)
+}
+
+func (rwm *ResponseWriterMock) Write(b []byte) (int, error) {
+	args := rwm.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (rwm *ResponseWriterMock) WriteHeader(h int) {
+	rwm.Called(h)
+}

--- a/testsmocks/responsewritermock/responsewriter_test.go
+++ b/testsmocks/responsewritermock/responsewriter_test.go
@@ -1,0 +1,55 @@
+/*
+ * UpdateHub
+ * Copyright (C) 2017
+ * O.S. Systems Sofware LTDA: contato@ossystems.com.br
+ *
+ * SPDX-License-Identifier:     GPL-2.0
+ */
+
+package responsewritermock
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeader(t *testing.T) {
+	rwm := &ResponseWriterMock{}
+
+	expected := http.Header{}
+
+	rwm.On("Header").Return(expected)
+	h := rwm.Header()
+
+	assert.Equal(t, expected, h)
+
+	rwm.AssertExpectations(t)
+}
+
+func TestWrite(t *testing.T) {
+	buffer := []byte("content")
+
+	rwm := &ResponseWriterMock{}
+
+	expectedError := fmt.Errorf("some error")
+
+	rwm.On("Write", buffer).Return(0, expectedError)
+	i, err := rwm.Write(buffer)
+
+	assert.Equal(t, expectedError, err)
+	assert.Equal(t, 0, i)
+
+	rwm.AssertExpectations(t)
+}
+
+func TestWriteHeader(t *testing.T) {
+	rwm := &ResponseWriterMock{}
+
+	rwm.On("WriteHeader", 200).Return()
+	rwm.WriteHeader(200)
+
+	rwm.AssertExpectations(t)
+}

--- a/updatehub/cancellable_state.go
+++ b/updatehub/cancellable_state.go
@@ -30,15 +30,11 @@ func (cs *CancellableState) Cancel(ok bool, nextState State) bool {
 	cs.nextStateMutex.Lock()
 	defer cs.nextStateMutex.Unlock()
 
-	cs.cancel <- ok
-	/*
-		//FIXME
-				// "non-blocking" write to channel
-				select {
-				case cs.cancel <- ok:
-				default:
-				}
-	*/
+	select {
+	case cs.cancel <- ok:
+	default:
+	}
+
 	cs.nextState = nextState
 
 	return ok

--- a/updatehub/daemon.go
+++ b/updatehub/daemon.go
@@ -25,19 +25,10 @@ func (d *Daemon) Stop() {
 
 func (d *Daemon) Run() int {
 	for {
-		d.uh.ReportCurrentState()
+		nextState := d.uh.ProcessCurrentState()
 
-		state, cancel := d.uh.State.Handle(d.uh)
-
-		cs, ok := d.uh.State.(*CancellableState)
-		if cancel && ok {
-			d.uh.State = cs.NextState()
-		} else {
-			d.uh.State = state
-		}
-
-		if d.stop || state.ID() == UpdateHubStateExit {
-			if finalState, _ := state.(*ExitState); finalState != nil {
+		if d.stop || nextState.ID() == UpdateHubStateExit {
+			if finalState, _ := nextState.(*ExitState); finalState != nil {
 				return finalState.exitCode
 			}
 

--- a/updatehub/idle_state_test.go
+++ b/updatehub/idle_state_test.go
@@ -73,10 +73,10 @@ func TestStateIdle(t *testing.T) {
 			uh.Settings = tc.settings
 
 			go func() {
-				uh.State.Cancel(false, NewIdleState()) // write
+				uh.Cancel(NewIdleState()) // write
 			}()
 
-			next, _ := uh.State.Handle(uh) // read
+			next, _ := uh.GetState().Handle(uh) // read
 			assert.IsType(t, tc.nextState, next)
 
 			aim.AssertExpectations(t)
@@ -84,7 +84,7 @@ func TestStateIdle(t *testing.T) {
 			expectedMap := map[string]interface{}{}
 			expectedMap["status"] = "idle"
 
-			assert.Equal(t, expectedMap, uh.State.ToMap())
+			assert.Equal(t, expectedMap, uh.GetState().ToMap())
 		})
 	}
 }

--- a/updatehub/installed_state_test.go
+++ b/updatehub/installed_state_test.go
@@ -26,9 +26,8 @@ func TestStateInstalled(t *testing.T) {
 	assert.NoError(t, err)
 
 	nextState, _ := s.Handle(uh)
-	expectedState := NewRebootState()
 
-	assert.Equal(t, expectedState, nextState)
+	assert.IsType(t, &RebootState{}, nextState)
 	assert.Equal(t, m, s.UpdateMetadata())
 
 	aim.AssertExpectations(t)

--- a/updatehub/installing_state_test.go
+++ b/updatehub/installing_state_test.go
@@ -118,7 +118,7 @@ func TestStateInstallingWithUpdateMetadataAlreadyInstalled(t *testing.T) {
 	expectedState := NewWaitingForRebootState(m)
 	assert.Equal(t, expectedState, nextState)
 
-	uh.State = nextState
+	uh.SetState(nextState)
 
 	aim.AssertExpectations(t)
 	om.AssertExpectations(t)

--- a/updatehub/poll_state_test.go
+++ b/updatehub/poll_state_test.go
@@ -70,9 +70,9 @@ func TestPollingRetries(t *testing.T) {
 	uh.Settings.PollingInterval = time.Second
 	uh.Settings.LastPoll = time.Now()
 
-	uh.State = NewPollState(uh.Settings.PollingInterval)
+	uh.SetState(NewPollState(uh.Settings.PollingInterval))
 
-	next, _ := uh.State.Handle(uh)
+	next, _ := uh.GetState().Handle(uh)
 	assert.IsType(t, &UpdateProbeState{}, next)
 
 	for i := 1; i < 3; i++ {
@@ -158,7 +158,7 @@ func TestPolling(t *testing.T) {
 
 			uh.StartPolling()
 
-			poll := uh.State
+			poll := uh.GetState()
 			assert.IsType(t, &PollState{}, poll)
 
 			poll.Handle(uh)

--- a/updatehub/settings.go
+++ b/updatehub/settings.go
@@ -41,11 +41,8 @@ var DefaultSettings = Settings{
 	},
 
 	UpdateSettings: UpdateSettings{
-		DownloadDir:               "/tmp",
-		AutoDownloadWhenAvailable: true,
-		AutoInstallAfterDownload:  true,
-		AutoRebootAfterInstall:    true,
-		SupportedInstallModes:     []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+		DownloadDir:           "/tmp",
+		SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
 	},
 
 	NetworkSettings: NetworkSettings{
@@ -88,11 +85,8 @@ type StorageSettings struct {
 }
 
 type UpdateSettings struct {
-	DownloadDir               string   `ini:"DownloadDir" json:"download-dir"`
-	AutoDownloadWhenAvailable bool     `ini:"AutoDownloadWhenAvailable" json:"auto-download-when-available"`
-	AutoInstallAfterDownload  bool     `ini:"AutoInstallAfterDownload" json:"auto-install-after-download"`
-	AutoRebootAfterInstall    bool     `ini:"AutoRebootAfterInstall" json:"auto-reboot-after-install"`
-	SupportedInstallModes     []string `ini:"SupportedInstallModes" json:"supported-install-modes"`
+	DownloadDir           string   `ini:"DownloadDir" json:"download-dir"`
+	SupportedInstallModes []string `ini:"SupportedInstallModes" json:"supported-install-modes"`
 }
 
 type NetworkSettings struct {

--- a/updatehub/settings_test.go
+++ b/updatehub/settings_test.go
@@ -31,9 +31,6 @@ ReadOnly=true
 
 [Update]
 DownloadDir=/tmp/download
-AutoDownloadWhenAvailable=false
-AutoInstallAfterDownload=false
-AutoRebootAfterInstall=false
 SupportedInstallModes=mode1,mode2
 
 [Network]
@@ -61,11 +58,8 @@ func TestToString(t *testing.T) {
 		},
 
 		UpdateSettings: UpdateSettings{
-			DownloadDir:               "/tmp",
-			AutoDownloadWhenAvailable: true,
-			AutoInstallAfterDownload:  true,
-			AutoRebootAfterInstall:    true,
-			SupportedInstallModes:     []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+			DownloadDir:           "/tmp",
+			SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
 		},
 
 		NetworkSettings: NetworkSettings{
@@ -97,9 +91,6 @@ func TestLoadSettingsDefaultValues(t *testing.T) {
 	assert.Equal(t, false, s.StorageSettings.ReadOnly)
 
 	assert.Equal(t, "/tmp", s.UpdateSettings.DownloadDir)
-	assert.Equal(t, true, s.UpdateSettings.AutoDownloadWhenAvailable)
-	assert.Equal(t, true, s.UpdateSettings.AutoInstallAfterDownload)
-	assert.Equal(t, true, s.UpdateSettings.AutoRebootAfterInstall)
 	assert.Equal(t, []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"}, s.UpdateSettings.SupportedInstallModes)
 
 	assert.Equal(t, "api.updatehub.io", s.NetworkSettings.ServerAddress)
@@ -134,11 +125,8 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				UpdateSettings: UpdateSettings{
-					DownloadDir:               "/tmp",
-					AutoDownloadWhenAvailable: true,
-					AutoInstallAfterDownload:  true,
-					AutoRebootAfterInstall:    true,
-					SupportedInstallModes:     []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+					DownloadDir:           "/tmp",
+					SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
 				},
 
 				NetworkSettings: NetworkSettings{
@@ -172,11 +160,8 @@ func TestLoadSettings(t *testing.T) {
 				},
 
 				UpdateSettings: UpdateSettings{
-					DownloadDir:               "/tmp/download",
-					AutoDownloadWhenAvailable: false,
-					AutoInstallAfterDownload:  false,
-					AutoRebootAfterInstall:    false,
-					SupportedInstallModes:     []string{"mode1", "mode2"},
+					DownloadDir:           "/tmp/download",
+					SupportedInstallModes: []string{"mode1", "mode2"},
 				},
 
 				NetworkSettings: NetworkSettings{

--- a/updatehub/states.go
+++ b/updatehub/states.go
@@ -49,6 +49,7 @@ const (
 )
 
 var statusNames = map[UpdateHubState]string{
+	UpdateHubDummyState:            "dummy",
 	UpdateHubStateIdle:             "idle",
 	UpdateHubStatePoll:             "poll",
 	UpdateHubStateUpdateProbe:      "update-probe",

--- a/updatehub/updateprobe_state.go
+++ b/updatehub/updateprobe_state.go
@@ -8,7 +8,9 @@
 
 package updatehub
 
-import "time"
+import (
+	"time"
+)
 
 // UpdateProbeState is the State interface implementation for the UpdateHubStateUpdateProbe
 type UpdateProbeState struct {

--- a/updatehub/updateprobe_state_test.go
+++ b/updatehub/updateprobe_state_test.go
@@ -78,7 +78,7 @@ func TestStateUpdateProbe(t *testing.T) {
 			uh.Controller = tc.controller
 			uh.Settings = tc.settings
 
-			next, _ := uh.State.Handle(uh)
+			next, _ := uh.GetState().Handle(uh)
 
 			assert.IsType(t, tc.nextState, next)
 
@@ -115,7 +115,7 @@ func TestStateUpdateProbeWithUpdateAvailableButAlreadyInstalled(t *testing.T) {
 	uh.Controller = cm
 	uh.Settings = &Settings{}
 
-	next, _ := uh.State.Handle(uh)
+	next, _ := uh.GetState().Handle(uh)
 
 	assert.IsType(t, &WaitingForRebootState{}, next)
 


### PR DESCRIPTION
- several HTTP routes removed

- callbacks added
-- State change ("/usr/share/updatehub/state-change-callback"): is
   executed before and after a state is handled. Ex.:
   <callback> enter <state>
   <callback> leave <state>
-- Error ("/usr/share/updatehub/error-callback"): is executed every
   time an error is handled. Ex.:
   <callback> error_message

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>