### PR TITLE
cmd/updatehub/main.go: don't use mergo to merge settings

### DIFF
--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -84,11 +83,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = loadSettings(osFs, settings, settings.RuntimeSettingsPath)
+	runtimeSettings := &updatehub.Settings{}
+	err = loadSettings(osFs, runtimeSettings, settings.RuntimeSettingsPath)
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatal(err)
 		os.Exit(1)
 	}
+
+	settings.PersistentPollingSettings = runtimeSettings.PersistentPollingSettings
 
 	log.Info("starting UpdateHub Agent")
 	log.Info("    version: ", gitversion)
@@ -160,10 +162,7 @@ func loadSettings(fs afero.Fs, structToSaveOn *updatehub.Settings, pathToLoadFro
 		return err
 	}
 
-	err = mergo.Merge(structToSaveOn, s)
-	if err != nil {
-		return err
-	}
+	*structToSaveOn = *s
 
 	return nil
 }

--- a/cmd/updatehub/main_test.go
+++ b/cmd/updatehub/main_test.go
@@ -99,10 +99,10 @@ func TestLoadSettings(t *testing.T) {
 			func() updatehub.Settings {
 				s := updatehub.DefaultSettings
 
-				s.ReadOnly = true
+				s.ReadOnly = false
 				s.ExtraPollingInterval = 3
-				s.LastPoll = time.Time{}
-				s.FirstPoll = time.Time{}
+				s.LastPoll = (time.Time{}).UTC()
+				s.FirstPoll = (time.Time{}).UTC()
 
 				return s
 			}(),


### PR DESCRIPTION
"Merging" manually. This is because we can't control which setting has
priority over the other on the same key. Mergo always consider
priority the non-zero values.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>