### PR TITLE
report previous state

### DIFF
--- a/client/report.go
+++ b/client/report.go
@@ -23,13 +23,14 @@ type ReportClient struct {
 }
 
 type Reporter interface {
-	ReportState(api ApiRequester, packageUID string, state string, errorMessage string, fm metadata.FirmwareMetadata) error
+	ReportState(api ApiRequester, packageUID string, previousState string, state string, errorMessage string, fm metadata.FirmwareMetadata) error
 }
 
-func (u *ReportClient) ReportState(api ApiRequester, packageUID string, state string, errorMessage string, fm metadata.FirmwareMetadata) error {
+func (u *ReportClient) ReportState(api ApiRequester, packageUID string, previousState string, state string, errorMessage string, fm metadata.FirmwareMetadata) error {
 	log.Debug("reporting state: ", state)
 	log.Debug("  error message: ", errorMessage)
 	log.Debug("  packageUID: ", packageUID)
+	log.Debug("  previous state: ", previousState)
 
 	if api == nil {
 		finalErr := fmt.Errorf("invalid api requester")
@@ -41,6 +42,7 @@ func (u *ReportClient) ReportState(api ApiRequester, packageUID string, state st
 
 	data := make(map[string]interface{})
 	data["status"] = state
+	data["previous-state"] = previousState
 	data["package-uid"] = packageUID
 	data["error-message"] = errorMessage
 

--- a/client/report_test.go
+++ b/client/report_test.go
@@ -78,7 +78,7 @@ func TestReportState(t *testing.T) {
 		Version:  "2.2",
 	}
 
-	err = reporter.ReportState(c.Request(), "packageUID", "state", "err_msg", fm)
+	err = reporter.ReportState(c.Request(), "packageUID", "previous_state", "state", "err_msg", fm)
 	assert.NoError(t, err)
 
 	var body map[string]interface{}
@@ -94,6 +94,7 @@ func TestReportState(t *testing.T) {
 	expectedBody["hardware"] = "board"
 	expectedBody["product-uid"] = "229ffd7e08721d716163fc81a2dbaf6c90d449f0a3b009b6a2defe8a0b0d7381"
 	expectedBody["device-identity"] = map[string]interface{}{"id1": "value1"}
+	expectedBody["previous-state"] = "previous_state"
 
 	assert.Equal(t, expectedBody, body)
 

--- a/testsmocks/reportermock/reporter.go
+++ b/testsmocks/reportermock/reporter.go
@@ -18,7 +18,7 @@ type ReporterMock struct {
 	mock.Mock
 }
 
-func (rm *ReporterMock) ReportState(api client.ApiRequester, packageUID string, state string, errorMessage string, fm metadata.FirmwareMetadata) error {
-	args := rm.Called(api, packageUID, state, errorMessage, fm)
+func (rm *ReporterMock) ReportState(api client.ApiRequester, packageUID string, previousState string, state string, errorMessage string, fm metadata.FirmwareMetadata) error {
+	args := rm.Called(api, packageUID, previousState, state, errorMessage, fm)
 	return args.Error(0)
 }

--- a/testsmocks/reportermock/reporter_test.go
+++ b/testsmocks/reportermock/reporter_test.go
@@ -30,12 +30,12 @@ func TestReportState(t *testing.T) {
 		Version:  "2.2",
 	}
 
-	rm.On("ReportState", ar, "sha256sum1", "idle", "", fm).Return(nil).Once()
-	err := rm.ReportState(ar, "sha256sum1", "idle", "", fm)
+	rm.On("ReportState", ar, "sha256sum1", "installed", "idle", "", fm).Return(nil).Once()
+	err := rm.ReportState(ar, "sha256sum1", "installed", "idle", "", fm)
 	assert.NoError(t, err)
 
-	rm.On("ReportState", ar, "sha256sum2", "downloading", "", fm).Return(fmt.Errorf("report error")).Once()
-	err = rm.ReportState(ar, "sha256sum2", "downloading", "", fm)
+	rm.On("ReportState", ar, "sha256sum2", "poll", "downloading", "", fm).Return(fmt.Errorf("report error")).Once()
+	err = rm.ReportState(ar, "sha256sum2", "poll", "downloading", "", fm)
 	assert.EqualError(t, err, "report error")
 
 	rm.AssertExpectations(t)

--- a/updatehub/daemon_test.go
+++ b/updatehub/daemon_test.go
@@ -51,7 +51,8 @@ func TestDaemonRun(t *testing.T) {
 
 	state := NewStateTest(d)
 
-	uh.SetState(state)
+	uh.previousState = NewIdleState()
+	uh.state = state
 	uh.Store = fs
 
 	d.Run()
@@ -84,7 +85,7 @@ func TestDaemonExitStateStop(t *testing.T) {
 	uh, _ := newTestUpdateHub(nil, aim)
 	uh.Reporter = rm
 
-	rm.On("ReportState", uh.API.Request(), "", "error", "err_msg", uh.FirmwareMetadata).Return(nil).Once()
+	rm.On("ReportState", uh.API.Request(), "", "", "error", "err_msg", uh.FirmwareMetadata).Return(nil).Once()
 
 	d := NewDaemon(uh)
 

--- a/updatehub/updatehub_test.go
+++ b/updatehub/updatehub_test.go
@@ -236,8 +236,9 @@ func TestProcessCurrentStateIsError(t *testing.T) {
 	uh.CmdLineExecuter = cm
 	uh.Reporter = rm
 	uh.Store = fs
+	uh.previousState = NewIdleState()
 
-	rm.On("ReportState", uh.API.Request(), "", "error", "some error", uh.FirmwareMetadata).Return(nil).Once()
+	rm.On("ReportState", uh.API.Request(), "", "idle", "error", "some error", uh.FirmwareMetadata).Return(nil).Once()
 
 	nextState := uh.ProcessCurrentState()
 
@@ -260,8 +261,9 @@ func TestProcessCurrentStateIsErrorWithNonExistantCallback(t *testing.T) {
 	uh.CmdLineExecuter = cm
 	uh.Reporter = rm
 	uh.Store = fs
+	uh.previousState = NewIdleState()
 
-	rm.On("ReportState", uh.API.Request(), "", "error", "some error", uh.FirmwareMetadata).Return(nil).Once()
+	rm.On("ReportState", uh.API.Request(), "", "idle", "error", "some error", uh.FirmwareMetadata).Return(nil).Once()
 
 	nextState := uh.ProcessCurrentState()
 
@@ -1570,9 +1572,10 @@ func TestUpdateHubReportState(t *testing.T) {
 
 			uh, _ := newTestUpdateHub(state, aim)
 			uh.Reporter = rm
+			uh.previousState = NewIdleState()
 
 			// error the first report
-			rm.On("ReportState", uh.API.Request(), tc.expectedUMSha256sum, "downloading", "", uh.FirmwareMetadata).Return(fmt.Errorf("report error")).Once()
+			rm.On("ReportState", uh.API.Request(), tc.expectedUMSha256sum, "idle", "downloading", "", uh.FirmwareMetadata).Return(fmt.Errorf("report error")).Once()
 
 			err := uh.ReportCurrentState()
 			assert.EqualError(t, err, "report error")
@@ -1580,7 +1583,7 @@ func TestUpdateHubReportState(t *testing.T) {
 			// the subsequent reports are successful. "Once()" is
 			// important here since the same state shouldn't be
 			// reported more than one time in a row
-			rm.On("ReportState", uh.API.Request(), tc.expectedUMSha256sum, "downloading", "", uh.FirmwareMetadata).Return(nil).Once()
+			rm.On("ReportState", uh.API.Request(), tc.expectedUMSha256sum, "idle", "downloading", "", uh.FirmwareMetadata).Return(nil).Once()
 
 			err = uh.ReportCurrentState()
 			assert.NoError(t, err)


### PR DESCRIPTION
The report JSON now also sends the field "previous-state". Useful on
error cases to discover where the error happened.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>