### PR TITLE
implement validate and rollback procedures

### DIFF
--- a/cmd/updatehub/constants.go
+++ b/cmd/updatehub/constants.go
@@ -22,4 +22,12 @@ const (
 	// handled. Ex.:
 	// <errorCallbackPath> 'error_message'
 	errorCallbackPath = "/usr/share/updatehub/error-callback"
+
+	// The validate callback is executed whenever a successful
+	// installation is booted.
+	validateCallbackPath = "/usr/share/updatehub/validate-callback"
+
+	// The rollback callback is executed whenever the agent boots
+	// after an errored installation boot
+	rollbackCallbackPath = "/usr/share/updatehub/rollback-callback"
 )

--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -98,6 +98,8 @@ func main() {
 	log.Info("    firmware metadata path: ", settings.FirmwareMetadataPath)
 	log.Info("    state change callback path: ", stateChangeCallbackPath)
 	log.Info("    error callback path: ", errorCallbackPath)
+	log.Info("    validate callback path: ", validateCallbackPath)
+	log.Info("    rollback callback path: ", rollbackCallbackPath)
 
 	log.Debug("settings:\n", settings.ToString())
 
@@ -115,7 +117,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	uh := updatehub.NewUpdateHub(gitversion, buildtime, stateChangeCallbackPath, errorCallbackPath, osFs, *fm, updatehub.NewIdleState(), settings, client.NewApiClient(address))
+	uh := updatehub.NewUpdateHub(gitversion, buildtime, stateChangeCallbackPath, errorCallbackPath, validateCallbackPath, rollbackCallbackPath, osFs, *fm, updatehub.NewIdleState(), settings, client.NewApiClient(address))
 
 	backend, err := server.NewAgentBackend(uh)
 	if err != nil {
@@ -136,7 +138,7 @@ func main() {
 
 	uh.Controller = uh
 
-	uh.StartPolling()
+	uh.Start()
 
 	log.Info("UpdateHub Agent started")
 

--- a/updatehub/poll_state_test.go
+++ b/updatehub/poll_state_test.go
@@ -156,7 +156,7 @@ func TestPolling(t *testing.T) {
 			uh.Settings.FirstPoll = tc.firstPoll
 			uh.Settings.LastPoll = tc.firstPoll
 
-			uh.StartPolling()
+			uh.Start()
 
 			poll := uh.GetState()
 			assert.IsType(t, &PollState{}, poll)

--- a/updatehub/settings.go
+++ b/updatehub/settings.go
@@ -45,6 +45,9 @@ var DefaultSettings = Settings{
 	UpdateSettings: UpdateSettings{
 		DownloadDir:           "/tmp",
 		SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+		PersistentUpdateSettings: PersistentUpdateSettings{
+			UpgradeToInstallation: -1,
+		},
 	},
 
 	NetworkSettings: NetworkSettings{
@@ -66,6 +69,7 @@ type Settings struct {
 
 type PersistentSettings struct {
 	PersistentPollingSettings `ini:"Polling"`
+	PersistentUpdateSettings  `ini:"Update"`
 }
 
 type PollingSettings struct {
@@ -88,8 +92,13 @@ type StorageSettings struct {
 }
 
 type UpdateSettings struct {
-	DownloadDir           string   `ini:"DownloadDir" json:"download-dir"`
-	SupportedInstallModes []string `ini:"SupportedInstallModes" json:"supported-install-modes"`
+	DownloadDir              string   `ini:"DownloadDir" json:"download-dir"`
+	SupportedInstallModes    []string `ini:"SupportedInstallModes" json:"supported-install-modes"`
+	PersistentUpdateSettings `ini:"Update"`
+}
+
+type PersistentUpdateSettings struct {
+	UpgradeToInstallation int `ini:"UpgradeToInstallation" json:"upgrade-to-installation"`
 }
 
 type NetworkSettings struct {
@@ -120,6 +129,7 @@ func (s *Settings) Save(fs afero.Fs) error {
 
 	ps := &PersistentSettings{
 		PersistentPollingSettings: s.PollingSettings.PersistentPollingSettings,
+		PersistentUpdateSettings:  s.UpdateSettings.PersistentUpdateSettings,
 	}
 
 	cfg := ini.Empty()

--- a/updatehub/settings_test.go
+++ b/updatehub/settings_test.go
@@ -93,6 +93,7 @@ func TestLoadSettingsDefaultValues(t *testing.T) {
 
 	assert.Equal(t, "/tmp", s.UpdateSettings.DownloadDir)
 	assert.Equal(t, []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"}, s.UpdateSettings.SupportedInstallModes)
+	assert.Equal(t, -1, s.UpdateSettings.PersistentUpdateSettings.UpgradeToInstallation)
 
 	assert.Equal(t, "api.updatehub.io", s.NetworkSettings.ServerAddress)
 
@@ -128,6 +129,9 @@ func TestLoadSettings(t *testing.T) {
 				UpdateSettings: UpdateSettings{
 					DownloadDir:           "/tmp",
 					SupportedInstallModes: []string{"dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs"},
+					PersistentUpdateSettings: PersistentUpdateSettings{
+						UpgradeToInstallation: -1,
+					},
 				},
 
 				NetworkSettings: NetworkSettings{
@@ -163,6 +167,9 @@ func TestLoadSettings(t *testing.T) {
 				UpdateSettings: UpdateSettings{
 					DownloadDir:           "/tmp/download",
 					SupportedInstallModes: []string{"mode1", "mode2"},
+					PersistentUpdateSettings: PersistentUpdateSettings{
+						UpgradeToInstallation: -1,
+					},
 				},
 
 				NetworkSettings: NetworkSettings{
@@ -205,6 +212,9 @@ FirstPoll=2017-02-02T00:00:00Z
 ExtraInterval=4
 Retries=5
 ProbeASAP=false
+
+[Update]
+UpgradeToInstallation=-1
 
 `
 	assert.Equal(t, expectedData, string(data))


### PR DESCRIPTION
They are procedures and not states, they are not reportable and
they run only once before the state machine starts.

When a "installed" state is achieved, it writes in the settings
the "UpgradeToInstallation"=? pointing to the new installation
index.

On the agent start, both validate and rollback states are ignored
when the "UpgradeToInstallation" is < 0 (-1 is the default value
when it's not set).

If "UpgradeToInstallation" is >= 0 AND is different from the current
active installation, a rollback procedure is launched. It just calls
the rollback callback and then go back to the state machine.

If "UpgradeToInstallation" is >= 0 AND is equal to the current active
installation, a validate procedure is launched. The validate procedure
calls the validate callback, if the callback succeeds, then it goes back
to the state machine. If the callback fails, it switches the active
partition and force a reboot.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>