### PR TITLE
.travis.yml: add go 1.9 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.7
   - 1.8
+  - 1.9
   - master
 
 go_import_path: github.com/UpdateHub/updatehub


### PR DESCRIPTION
Fixes #140.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>