### PR TITLE
ensure that the same object can be downloaded twice

### DIFF
--- a/server/server_backend.go
+++ b/server/server_backend.go
@@ -213,10 +213,13 @@ func (sb *ServerBackend) getObject(w http.ResponseWriter, r *http.Request, p htt
 	}
 
 	if sb.selectedPackage.uhupkgPath != "" {
+		// is uhupkg in the directory
+
 		fileName := p.ByName("object")
 
 		// package was already parsed, we can safely ignore the error here
 		reader, _ := libarchive.NewReader(sb.LibArchive, sb.selectedPackage.uhupkgPath, 10240)
+		defer reader.Free()
 
 		err := reader.ExtractFile(fileName, w)
 		if err != nil {
@@ -226,6 +229,8 @@ func (sb *ServerBackend) getObject(w http.ResponseWriter, r *http.Request, p htt
 			return
 		}
 	} else {
+		// is updatemetadata.json in the directory
+
 		fileName := path.Join(sb.path, p.ByName("product"), p.ByName("package"), p.ByName("object"))
 		http.ServeFile(w, r, fileName)
 	}


### PR DESCRIPTION
Since libarchive doesn't support seek, we need to be careful when
using the "libarchive.Reader" struct. We need te create a new Reader
struct every time we do an extraction so we ensure the internal
pointer of the archive is reset. On uhupkg files this doesn't impact
on performance since it uses "zip" format on which the files are
indexed.

The server backend implementation was already correct but a test was
missing to ensure that.

Signed-off-by: Giulian Gonçalves Vivan <giulian@ossystems.com.br>