### PR TITLE
updatehub-server: force usage of http instead of https

### DIFF
--- a/cmd/updatehub-server/main.go
+++ b/cmd/updatehub-server/main.go
@@ -134,7 +134,7 @@ func main() {
 		var req struct {
 			ServerAddress string `json:"server-address"`
 		}
-		req.ServerAddress = "localhost:8088"
+		req.ServerAddress = "http://localhost:8088"
 
 		// Probe for update
 		_, _, errs := gorequest.New().Post(buildURL("/probe")).Send(req).EndStruct(&probe)


### PR DESCRIPTION
Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>