### PR TITLE
FileSha256sum: Copy bytes from reader to writer instead of reading entire file

### DIFF
--- a/updatehub/updatehub_test.go
+++ b/updatehub/updatehub_test.go
@@ -358,7 +358,7 @@ func TestCheckDownloadedObjectSha256sumWithOpenError(t *testing.T) {
 	dummySha256sum := "dummy_hash"
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
-	fsm.On("Open", path.Join(dummyPath, dummySha256sum)).Return(&filemock.FileMock{}, fmt.Errorf("open error"))
+	fsm.On("OpenFile", path.Join(dummyPath, dummySha256sum), os.O_RDONLY, os.FileMode(0)).Return(&filemock.FileMock{}, fmt.Errorf("open error"))
 
 	sci := &Sha256CheckerImpl{}
 	err := sci.CheckDownloadedObjectSha256sum(fsm, dummyPath, dummySha256sum)
@@ -721,21 +721,21 @@ func TestUpdateHubDownloadUpdate(t *testing.T) {
 	target1 := &filemock.FileMock{}
 	target1.On("Close").Return(nil).Once()
 	cpm.On("Copy", target1, source1, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, nil).Once()
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUID1)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUID1), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUID1)).Return(target1, nil).Once()
 
 	// file2
 	target2 := &filemock.FileMock{}
 	target2.On("Close").Return(nil).Once()
 	cpm.On("Copy", target2, source2, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, nil).Once()
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUID2)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUID2), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUID2)).Return(target2, nil).Once()
 
 	// file3
 	target3 := &filemock.FileMock{}
 	target3.On("Close").Return(nil).Once()
 	cpm.On("Copy", target3, source3, 30*time.Second, (<-chan bool)(nil), utils.ChunkSize, 0, -1, false).Return(false, nil).Once()
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUID3)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUID3), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUID3)).Return(target3, nil).Once()
 
 	progressList, err := startDownloadUpdateInAnotherFunc(uh.DefaultApiClient, uh, updateMetadata)
@@ -844,7 +844,7 @@ func TestUpdateHubDownloadUpdateWithTargetFileError(t *testing.T) {
 	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUID)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUID), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUID)).Return((*filemock.FileMock)(nil), fmt.Errorf("create error"))
 	uh.Store = fsm
 
@@ -906,7 +906,7 @@ func TestUpdateHubDownloadUpdateWithUpdaterError(t *testing.T) {
 	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUID)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUID), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUID)).Return(target, nil)
 	uh.Store = fsm
 
@@ -973,7 +973,7 @@ func TestUpdateHubDownloadUpdateWithCopyError(t *testing.T) {
 	uh.CopyBackend = cpm
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUID)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUID), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUID)).Return(target, nil)
 	uh.Store = fsm
 
@@ -1059,9 +1059,9 @@ func TestUpdateHubDownloadUpdateWithActiveInactive(t *testing.T) {
 	target2.On("Close").Return(nil)
 
 	fsm := &filesystemmock.FileSystemBackendMock{}
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUIDFirst)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUIDFirst), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUIDFirst)).Return(target1, nil)
-	fsm.On("Open", path.Join(uh.Settings.DownloadDir, objectUIDSecond)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
+	fsm.On("OpenFile", path.Join(uh.Settings.DownloadDir, objectUIDSecond), os.O_RDONLY, os.FileMode(0)).Return((*filemock.FileMock)(nil), fmt.Errorf("not found")).Once()
 	fsm.On("Create", path.Join(uh.Settings.DownloadDir, objectUIDSecond)).Return(target2, nil)
 	uh.Store = fsm
 

--- a/utils/sha.go
+++ b/utils/sha.go
@@ -11,6 +11,8 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
+	"os"
 
 	"github.com/spf13/afero"
 )
@@ -25,10 +27,14 @@ func DataSha256sum(data []byte) string {
 }
 
 func FileSha256sum(fsb afero.Fs, filepath string) (string, error) {
-	data, err := afero.ReadFile(fsb, filepath)
+	f, err := fsb.OpenFile(filepath, os.O_RDONLY, 0)
 	if err != nil {
 		return "", err
 	}
 
-	return DataSha256sum(data), nil
+	hash := sha256.New()
+
+	_, _ = io.Copy(hash, f)
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }


### PR DESCRIPTION
This avoids high memory usage when reading huge file