### PR TITLE
server: create a instance of apiclient when server-address is given

### DIFF
--- a/server/agent_backend.go
+++ b/server/agent_backend.go
@@ -76,7 +76,7 @@ func (ab *AgentBackend) probe(w http.ResponseWriter, r *http.Request, p httprout
 
 			if err != nil {
 				log.Warn("failed to sanitize a server address from /probe request: ", err)
-			} else if ab.DefaultApiClient == nil {
+			} else {
 				apiClient = client.NewApiClient(sanitizedAddress)
 			}
 		}

--- a/server/agent_backend_test.go
+++ b/server/agent_backend_test.go
@@ -306,6 +306,8 @@ func TestProbeRouteWithServerAddressField(t *testing.T) {
 			defer teardown(t)
 
 			apiClient := client.NewApiClient(tc.ExpectedURL)
+			// Not needed for this test case
+			apiClient.CheckRedirect = nil
 
 			uh.TimeStep = time.Second
 			s := updatehub.NewIdleState()
@@ -314,7 +316,11 @@ func TestProbeRouteWithServerAddressField(t *testing.T) {
 			cm := &controllermock.ControllerMock{}
 
 			uh.Controller = cm
-			cm.On("ProbeUpdate", apiClient, 5).Return((*metadata.UpdateMetadata)(nil), []byte{}, 3600*time.Second)
+			cm.On("ProbeUpdate", mock.MatchedBy(func(actual *client.ApiClient) bool {
+				// Not needed for this test case
+				actual.CheckRedirect = nil
+				return reflect.DeepEqual(actual, apiClient)
+			}), 5).Return((*metadata.UpdateMetadata)(nil), []byte{}, 3600*time.Second)
 
 			rwm := &responsewritermock.ResponseWriterMock{}
 			rwm.On("WriteHeader", 200)


### PR DESCRIPTION
CheckRedirect is setted to nil because when comparing two structs with
non-nil function pointer, reflect.DeepEqual will return false.

See discussion about this behaviour here: https://github.com/golang/go/issues/8554