### PR TITLE
activeinactive: implement 'SetValidate' function

### DIFF
--- a/activeinactive/activeinactive.go
+++ b/activeinactive/activeinactive.go
@@ -21,6 +21,7 @@ import (
 type Interface interface {
 	Active() (int, error)
 	SetActive(active int) error
+	SetValidate() error
 }
 
 // DefaultImpl is the default implementation for Interface
@@ -58,6 +59,21 @@ func (i *DefaultImpl) SetActive(active int) error {
 	_, err := i.Execute(fmt.Sprintf("updatehub-active-set %d", active))
 	if err != nil {
 		finalErr := fmt.Errorf("failed to execute 'updatehub-active-set': %s", err)
+		log.Error(finalErr)
+		return finalErr
+	}
+
+	return nil
+}
+
+// SetValidate validate the current update
+// by calling 'updatehub-active-validated'
+func (i *DefaultImpl) SetValidate() error {
+	log.Debug("Running 'updatehub-active-validated'")
+
+	_, err := i.Execute(fmt.Sprintf("updatehub-active-validated"))
+	if err != nil {
+		finalErr := fmt.Errorf("failed to execute 'updatehub-active-validated': %s", err)
 		log.Error(finalErr)
 		return finalErr
 	}

--- a/testsmocks/activeinactivemock/activeinactive.go
+++ b/testsmocks/activeinactivemock/activeinactive.go
@@ -23,3 +23,8 @@ func (aim *ActiveInactiveMock) SetActive(active int) error {
 	args := aim.Called(active)
 	return args.Error(0)
 }
+
+func (aim *ActiveInactiveMock) SetValidate() error {
+	args := aim.Called()
+	return args.Error(0)
+}

--- a/testsmocks/activeinactivemock/activeinactive_test.go
+++ b/testsmocks/activeinactivemock/activeinactive_test.go
@@ -41,3 +41,16 @@ func TestDownloadUpdate(t *testing.T) {
 
 	aim.AssertExpectations(t)
 }
+
+func TestValidateUpdate(t *testing.T) {
+	expectedError := fmt.Errorf("some error")
+
+	aim := &ActiveInactiveMock{}
+	aim.On("SetValidate").Return(expectedError)
+
+	err := aim.SetValidate()
+
+	assert.Equal(t, expectedError, err)
+
+	aim.AssertExpectations(t)
+}

--- a/updatehub/updatehub_test.go
+++ b/updatehub/updatehub_test.go
@@ -2035,6 +2035,8 @@ func TestStartWithSuccessfulInstallationValidation(t *testing.T) {
 	aim := &activeinactivemock.ActiveInactiveMock{}
 	aim.On("Active").Return(0, nil).Once()
 
+	aim.On("SetValidate").Return(nil)
+
 	uh, _ := newTestUpdateHub(nil, aim)
 
 	uh.Settings.ProbeASAP = true
@@ -2213,6 +2215,8 @@ func newTestUpdateHub(state State, aii activeinactive.Interface) (*UpdateHub, er
 func TestValidateProcedureWithNonExistantCallback(t *testing.T) {
 	aim := &activeinactivemock.ActiveInactiveMock{}
 
+	aim.On("SetValidate").Return(nil)
+
 	uh, err := newTestUpdateHub(nil, aim)
 	assert.NoError(t, err)
 
@@ -2233,6 +2237,8 @@ func TestValidateProcedureWithNonExistantCallback(t *testing.T) {
 
 func TestValidateProcedureWithCallbackSuccess(t *testing.T) {
 	aim := &activeinactivemock.ActiveInactiveMock{}
+
+	aim.On("SetValidate").Return(nil)
 
 	uh, err := newTestUpdateHub(nil, aim)
 	assert.NoError(t, err)


### PR DESCRIPTION
This allows to reset 'upgrade_available' to zero by calling update-active-activated script from 'validateProcedure'.

(based on PR #195 )