### PR TITLE
fixes load and update of UpgradeToInstallation variable

### DIFF
--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -94,6 +94,7 @@ func main() {
 	}
 
 	settings.PersistentPollingSettings = runtimeSettings.PersistentPollingSettings
+	settings.PersistentUpdateSettings = runtimeSettings.PersistentUpdateSettings
 
 	log.Info("starting UpdateHub Agent")
 	log.Info("    version: ", gitversion)

--- a/updatehub/updatehub.go
+++ b/updatehub/updatehub.go
@@ -496,6 +496,7 @@ func (uh *UpdateHub) InstallUpdate(updateMetadata *metadata.UpdateMetadata, prog
 		}
 
 		log.Info("ActiveInactive activated: ", indexToInstall)
+		uh.Settings.UpgradeToInstallation = indexToInstall
 	}
 
 	log.Info("update installed successfully")


### PR DESCRIPTION
Without this commit, the agent code reading 'UpgradeToInstallation'
from '/etc/updatehub.conf' and not from persistents data (/data)

Also fixes the update of 'UpgradeToInstallation' after an update.

Fixes #197

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>