### PR TITLE
updatehub: unshare mount namespace

### DIFF
--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"syscall"
 
 	"github.com/pkg/errors"
 
@@ -75,6 +76,18 @@ func main() {
 
 	if *isDebug {
 		log.SetLevel(logrus.DebugLevel)
+	}
+
+	// enter in a new mount NS for isolating changes to the mount table
+	if err := syscall.Unshare(syscall.CLONE_NEWNS); err != nil {
+		log.Fatalf("failed to enter private mount NS: %s", err)
+		os.Exit(1)
+	}
+
+	err = syscall.Mount("", "/", "updatehub", syscall.MS_REC|syscall.MS_SLAVE, "")
+	if err != nil {
+		log.Fatalf("failed to mark rootfs as rslave: %s", err)
+		os.Exit(1)
 	}
 
 	osFs := afero.NewOsFs()


### PR DESCRIPTION
Allow updatehubhub to have their own per-process private filesystem
mount points

Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>