### PR TITLE
updatehub-server: Remove mount command from udev rule

### DIFF
--- a/cmd/updatehub-server/udev.rules
+++ b/cmd/updatehub-server/udev.rules
@@ -3,7 +3,6 @@ ENV{ID_FS_LABEL}=="updatehub|UPDATEHUB", \
   ACTION=="add", \
   SUBSYSTEM=="block", \
   RUN+="/bin/mkdir -p /mnt/updatehub", \
-  RUN+="/bin/mount -o ro /dev/%k /mnt/updatehub", \
   RUN+="/bin/sh -c '/bin/echo /usr/bin/updatehub-server --mount /dev/%k --fstype $env{ID_FS_TYPE} --wait /mnt/updatehub | at -M now'"
 
 ENV{ID_FS_LABEL}=="updatehub|UPDATEHUB", \


### PR DESCRIPTION
Udev cannot mount this once UpdateHub server mounts device in
/mnt/updatehub.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>