### PR TITLE
copy: The return should be done even if `ok` fail

### DIFF
--- a/copy/copy.go
+++ b/copy/copy.go
@@ -77,12 +77,11 @@ Loop:
 		case err, ok := <-readErrChan:
 			if ok {
 				close(readErrChan)
-				return false, err
 			}
-		case _, ok := <-cancel:
-			if ok {
-				return true, nil
-			}
+			
+			return false, err
+		case <-cancel:
+			return true, nil
 		case <-time.After(timeout):
 			finalErr := fmt.Errorf("copy error: timeout")
 			log.Error(finalErr)


### PR DESCRIPTION
In case of cancellation or a read error, we need to stop the copy. The
condition is wrong as we should return as soon as possible.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>