### PR TITLE
installmodes/tarball: umount device only in cleanup method

### DIFF
--- a/installmodes/tarball/tarball.go
+++ b/installmodes/tarball/tarball.go
@@ -134,13 +134,6 @@ func (tb *TarballObject) Install(downloadDir string) error {
 		errorList = append(errorList, err)
 	}
 
-	umountErr := tb.Umount(tb.tempDirPath)
-	if umountErr != nil {
-		errorList = append(errorList, umountErr)
-	} else {
-		tb.FileSystemBackend.RemoveAll(tb.tempDirPath)
-	}
-
 	return utils.MergeErrorList(errorList)
 }
 


### PR DESCRIPTION
Also removes some specific tests for umount errors in install method
since it is already tested in cleanup tests

Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>