### PR TITLE
Fix import order

### DIFF
--- a/activeinactive/activeinactive_test.go
+++ b/activeinactive/activeinactive_test.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultImplActive(t *testing.T) {

--- a/client/report_test.go
+++ b/client/report_test.go
@@ -17,8 +17,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReportState(t *testing.T) {

--- a/client/update.go
+++ b/client/update.go
@@ -23,8 +23,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/anacrolix/missinggo/httptoo"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/anacrolix/missinggo/httptoo"
 )
 
 type UpdateClient struct {

--- a/client/update_test.go
+++ b/client/update_test.go
@@ -18,11 +18,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/UpdateHub/updatehub/installmodes/imxkobs"
+	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/anacrolix/missinggo/httptoo"
 	httputils "github.com/koofr/go-httputils"
 	"github.com/stretchr/testify/assert"
-	"github.com/UpdateHub/updatehub/installmodes/imxkobs"
-	"github.com/UpdateHub/updatehub/metadata"
 )
 
 func TestProbeUpdateWithInvalidApiRequester(t *testing.T) {

--- a/cmd/updatehub-ctl/main.go
+++ b/cmd/updatehub-ctl/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/UpdateHub/agent-sdk-go"
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/spf13/cobra"
-	"github.com/UpdateHub/agent-sdk-go"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/updatehub-server/main.go
+++ b/cmd/updatehub-server/main.go
@@ -16,10 +16,6 @@ import (
 	"time"
 
 	"github.com/OSSystems/pkg/log"
-	linuxproc "github.com/c9s/goprocinfo/linux"
-	"github.com/parnurzeal/gorequest"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	_ "github.com/UpdateHub/updatehub/installmodes/copy"
 	_ "github.com/UpdateHub/updatehub/installmodes/flash"
 	_ "github.com/UpdateHub/updatehub/installmodes/imxkobs"
@@ -30,6 +26,10 @@ import (
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/server"
 	"github.com/UpdateHub/updatehub/updatehub"
+	linuxproc "github.com/c9s/goprocinfo/linux"
+	"github.com/parnurzeal/gorequest"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 type AgentInfo struct {

--- a/cmd/updatehub/main.go
+++ b/cmd/updatehub/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	syslog_hook "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/UpdateHub/updatehub/client"
 	_ "github.com/UpdateHub/updatehub/installmodes/copy"
 	_ "github.com/UpdateHub/updatehub/installmodes/flash"
@@ -38,6 +37,7 @@ import (
 	"github.com/UpdateHub/updatehub/server"
 	"github.com/UpdateHub/updatehub/updatehub"
 	"github.com/UpdateHub/updatehub/utils"
+	syslog_hook "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 var (

--- a/cmd/updatehub/main_test.go
+++ b/cmd/updatehub/main_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-ini/ini"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 	"github.com/UpdateHub/updatehub/updatehub"
+	"github.com/go-ini/ini"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadSettings(t *testing.T) {

--- a/copy/copy.go
+++ b/copy/copy.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"github.com/OSSystems/pkg/log"
-	shellwords "github.com/mattn/go-shellwords"
-	"github.com/spf13/afero"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/utils"
+	shellwords "github.com/mattn/go-shellwords"
+	"github.com/spf13/afero"
 )
 
 type Interface interface {
@@ -78,7 +78,7 @@ Loop:
 			if ok {
 				close(readErrChan)
 			}
-			
+
 			return false, err
 		case <-cancel:
 			return true, nil

--- a/installifdifferent/installifdifferent.go
+++ b/installifdifferent/installifdifferent.go
@@ -14,9 +14,9 @@ import (
 	"os"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/spf13/afero"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
 )
 
 type Interface interface {

--- a/installifdifferent/installifdifferent_test.go
+++ b/installifdifferent/installifdifferent_test.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/filemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/installifdifferent/kernelfileinfo.go
+++ b/installifdifferent/kernelfileinfo.go
@@ -17,9 +17,9 @@ import (
 	"regexp"
 	"unicode"
 
-	"github.com/spf13/afero"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
 )
 
 type LinuxArch int

--- a/installifdifferent/kernelfileinfo_test.go
+++ b/installifdifferent/kernelfileinfo_test.go
@@ -13,11 +13,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/UpdateHub/updatehub/testsmocks/filemock"
+	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/UpdateHub/updatehub/testsmocks/filemock"
-	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 )
 
 func TestNewKernelFileInfo(t *testing.T) {

--- a/installmodes/copy/copy_test.go
+++ b/installmodes/copy/copy_test.go
@@ -15,8 +15,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
@@ -25,6 +23,8 @@ import (
 	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/permissionsmock"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCopyInit(t *testing.T) {

--- a/installmodes/imxkobs/imxkobs.go
+++ b/installmodes/imxkobs/imxkobs.go
@@ -14,11 +14,11 @@ import (
 	"strconv"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/spf13/afero"
 	"github.com/UpdateHub/updatehub/installifdifferent"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
 )
 
 func init() {

--- a/installmodes/mender/mender_test.go
+++ b/installmodes/mender/mender_test.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/testsmocks/filemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMenderInit(t *testing.T) {

--- a/installmodes/raw/raw_test.go
+++ b/installmodes/raw/raw_test.go
@@ -15,8 +15,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
@@ -24,6 +22,8 @@ import (
 	"github.com/UpdateHub/updatehub/testsmocks/filemock"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRawInit(t *testing.T) {

--- a/installmodes/tarball/tarball_test.go
+++ b/installmodes/tarball/tarball_test.go
@@ -13,8 +13,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/copy"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/libarchive"
@@ -25,6 +23,8 @@ import (
 	"github.com/UpdateHub/updatehub/testsmocks/mtdmock"
 	"github.com/UpdateHub/updatehub/testsmocks/ubifsmock"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTarballInit(t *testing.T) {

--- a/metadata/firmware_test.go
+++ b/metadata/firmware_test.go
@@ -15,10 +15,10 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewFirmwareMetadataWithInexistantPath(t *testing.T) {

--- a/metadata/object_test.go
+++ b/metadata/object_test.go
@@ -11,8 +11,8 @@ package metadata
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestObject struct {

--- a/metadata/update_test.go
+++ b/metadata/update_test.go
@@ -16,9 +16,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestObjectCompressed struct {

--- a/mtd/ubifs.go
+++ b/mtd/ubifs.go
@@ -14,8 +14,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/spf13/afero"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
 )
 
 type UbifsUtils interface {

--- a/mtd/ubifs_test.go
+++ b/mtd/ubifs_test.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 )
 
 const ubinfoStdoutTemplate string = `Volume ID:   %d (on ubi%d)

--- a/server/agent_backend.go
+++ b/server/agent_backend.go
@@ -15,10 +15,10 @@ import (
 	"net/http"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/julienschmidt/httprouter"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/updatehub"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/julienschmidt/httprouter"
 )
 
 type AgentBackend struct {

--- a/server/agent_backend_test.go
+++ b/server/agent_backend_test.go
@@ -18,9 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
@@ -29,6 +26,9 @@ import (
 	"github.com/UpdateHub/updatehub/testsmocks/reportermock"
 	"github.com/UpdateHub/updatehub/testsmocks/responsewritermock"
 	"github.com/UpdateHub/updatehub/updatehub"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const (

--- a/server/daemon.go
+++ b/server/daemon.go
@@ -12,8 +12,8 @@ import (
 	"path"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/fsnotify/fsnotify"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/fsnotify/fsnotify"
 )
 
 type Daemon struct {

--- a/server/daemon_test.go
+++ b/server/daemon_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewDaemon(t *testing.T) {

--- a/server/server_backend.go
+++ b/server/server_backend.go
@@ -19,10 +19,10 @@ import (
 	"strings"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/julienschmidt/httprouter"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/julienschmidt/httprouter"
 )
 
 type SelectedPackage struct {

--- a/server/server_backend_test.go
+++ b/server/server_backend_test.go
@@ -24,12 +24,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/libarchive"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/libarchivemock"
 	"github.com/UpdateHub/updatehub/utils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/testsmocks/controllermock/controller.go
+++ b/testsmocks/controllermock/controller.go
@@ -11,9 +11,9 @@ package controllermock
 import (
 	"time"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/mock"
 )
 
 type ControllerMock struct {

--- a/testsmocks/controllermock/controller_test.go
+++ b/testsmocks/controllermock/controller_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProbeUpdate(t *testing.T) {

--- a/testsmocks/copymock/copy_test.go
+++ b/testsmocks/copymock/copy_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCopyFile(t *testing.T) {

--- a/testsmocks/installifdifferentmock/installifdifferent.go
+++ b/testsmocks/installifdifferentmock/installifdifferent.go
@@ -9,8 +9,8 @@
 package installifdifferentmock
 
 import (
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/mock"
 )
 
 type InstallIfDifferentMock struct {

--- a/testsmocks/installifdifferentmock/installifdifferent_test.go
+++ b/testsmocks/installifdifferentmock/installifdifferent_test.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes/copy"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/testsmocks/libarchivemock/libarchive_test.go
+++ b/testsmocks/libarchivemock/libarchive_test.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/libarchive"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewRead(t *testing.T) {

--- a/testsmocks/objectmock/object.go
+++ b/testsmocks/objectmock/object.go
@@ -9,8 +9,8 @@
 package objectmock
 
 import (
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/mock"
 )
 
 type ObjectMock struct {

--- a/testsmocks/reportermock/reporter.go
+++ b/testsmocks/reportermock/reporter.go
@@ -9,9 +9,9 @@
 package reportermock
 
 import (
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/mock"
 )
 
 type ReporterMock struct {

--- a/testsmocks/reportermock/reporter_test.go
+++ b/testsmocks/reportermock/reporter_test.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReportState(t *testing.T) {

--- a/testsmocks/updatermock/updater.go
+++ b/testsmocks/updatermock/updater.go
@@ -12,9 +12,9 @@ import (
 	"io"
 	"time"
 
+	"github.com/UpdateHub/updatehub/client"
 	"github.com/anacrolix/missinggo/httptoo"
 	"github.com/stretchr/testify/mock"
-	"github.com/UpdateHub/updatehub/client"
 )
 
 type UpdaterMock struct {

--- a/testsmocks/updatermock/updater_test.go
+++ b/testsmocks/updatermock/updater_test.go
@@ -15,11 +15,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anacrolix/missinggo/httptoo"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/installmodes/copy"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/anacrolix/missinggo/httptoo"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/updatehub/daemon_test.go
+++ b/updatehub/daemon_test.go
@@ -13,13 +13,13 @@ import (
 	"testing"
 
 	"github.com/OSSystems/pkg/log"
+	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
+	"github.com/UpdateHub/updatehub/testsmocks/reportermock"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
-	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
-	"github.com/UpdateHub/updatehub/testsmocks/reportermock"
 )
 
 func TestNewDaemon(t *testing.T) {

--- a/updatehub/downloaded_state_test.go
+++ b/updatehub/downloaded_state_test.go
@@ -11,11 +11,11 @@ package updatehub
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStateDownloaded(t *testing.T) {

--- a/updatehub/downloading_state.go
+++ b/updatehub/downloading_state.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/pkg/errors"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/pkg/errors"
 )
 
 // DownloadingState is the State interface implementation for the UpdateHubStateDownloading

--- a/updatehub/downloading_state_test.go
+++ b/updatehub/downloading_state_test.go
@@ -12,16 +12,16 @@ import (
 	"errors"
 	"testing"
 
-	errs "github.com/pkg/errors"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/controllermock"
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
 	"github.com/UpdateHub/updatehub/testsmocks/progresstrackermock"
+	errs "github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestStateDownloadingWithSuccess(t *testing.T) {

--- a/updatehub/error_state_test.go
+++ b/updatehub/error_state_test.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/client"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewErrorStateToMap(t *testing.T) {

--- a/updatehub/idle_state_test.go
+++ b/updatehub/idle_state_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewIdleState(t *testing.T) {

--- a/updatehub/installed_state_test.go
+++ b/updatehub/installed_state_test.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStateInstalled(t *testing.T) {

--- a/updatehub/installing_state.go
+++ b/updatehub/installing_state.go
@@ -11,9 +11,9 @@ package updatehub
 import (
 	"sync"
 
-	"github.com/spf13/afero"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/spf13/afero"
 )
 
 // InstallingState is the State interface implementation for the UpdateHubStateInstalling

--- a/updatehub/installing_state_test.go
+++ b/updatehub/installing_state_test.go
@@ -12,9 +12,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
@@ -24,6 +21,9 @@ import (
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
 	"github.com/UpdateHub/updatehub/testsmocks/progresstrackermock"
 	"github.com/UpdateHub/updatehub/testsmocks/statesmock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestStateInstallingWithSuccess(t *testing.T) {

--- a/updatehub/poll_state_test.go
+++ b/updatehub/poll_state_test.go
@@ -16,13 +16,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bouk/monkey"
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/controllermock"
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
+	"github.com/bouk/monkey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewPollState(t *testing.T) {

--- a/updatehub/probe_state.go
+++ b/updatehub/probe_state.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/OSSystems/pkg/log"
-	"github.com/pkg/errors"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/metadata"
+	"github.com/pkg/errors"
 )
 
 // ProbeState is the State interface implementation for the UpdateHubStateProbe

--- a/updatehub/probe_state_test.go
+++ b/updatehub/probe_state_test.go
@@ -19,16 +19,16 @@ import (
 	"testing"
 	"time"
 
-	errs "github.com/pkg/errors"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/activeinactivemock"
 	"github.com/UpdateHub/updatehub/testsmocks/controllermock"
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
+	errs "github.com/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestStateProbeWithUpdateAvailable(t *testing.T) {

--- a/updatehub/rebooting_state_test.go
+++ b/updatehub/rebooting_state_test.go
@@ -12,12 +12,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/UpdateHub/updatehub/client"
 	"github.com/UpdateHub/updatehub/installmodes"
 	"github.com/UpdateHub/updatehub/metadata"
 	"github.com/UpdateHub/updatehub/testsmocks/objectmock"
 	"github.com/UpdateHub/updatehub/testsmocks/rebootermock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStateRebootingID(t *testing.T) {

--- a/updatehub/settings.go
+++ b/updatehub/settings.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/OSSystems/pkg/log"
+	"github.com/UpdateHub/updatehub/utils"
 	"github.com/go-ini/ini"
 	"github.com/spf13/afero"
-	"github.com/UpdateHub/updatehub/utils"
 )
 
 const (

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -14,9 +14,9 @@ import (
 	"path"
 	"testing"
 
+	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/UpdateHub/updatehub/testsmocks/filesystemmock"
 )
 
 func TestApplyChmod(t *testing.T) {

--- a/utils/filesystem_test.go
+++ b/utils/filesystem_test.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"github.com/UpdateHub/updatehub/testsmocks/cmdlinemock"
 )
 
 func TestFormat(t *testing.T) {


### PR DESCRIPTION
After renaming project to UpdateHub the import order of packages
should have been changed as a result of this mistake, every time
that I modify a file in my editor the import order of packages
is changed causing unwanted changes in the file. This commit fixes it