### PR TITLE
general: Add support for installing package from url

### DIFF
--- a/doc/agent-http.yaml
+++ b/doc/agent-http.yaml
@@ -86,6 +86,33 @@ paths:
               schema:
                 $ref: "#/components/schemas/AgentStatus"
 
+  "/remote_install":
+    post:
+      summary: "Download and install package from remote url"
+      description: |-
+        Request the agent for installation of a remote package.
+      requestBody:
+        required: true
+        description: "Remote url that offers the update pacakge"
+        content:
+          text/plain:
+            schema:
+              type: string
+              example: "https://some_remote_url.domain/update.uhupkg"
+      responses:
+        "200":
+          description: "Request accepted"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentStatus"
+        "422":
+          description: "Remote instalation cond't start"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentStatus"
+
   "/update/download/abort":
     post:
       summary: "Abort download"

--- a/updatehub/src/states/actor/mod.rs
+++ b/updatehub/src/states/actor/mod.rs
@@ -9,11 +9,13 @@ pub(crate) mod download_abort;
 pub(crate) mod info;
 pub(crate) mod local_install;
 pub(crate) mod probe;
+pub(crate) mod remote_install;
 /// Used to send `Step` messages to the `Machine` actor.
 pub(crate) mod stepper;
 
 use super::{
-    Idle, Metadata, PrepareLocalInstall, Probe, RuntimeSettings, Settings, State, StateMachine,
+    DirectDownload, Idle, Metadata, PrepareLocalInstall, Probe, RuntimeSettings, Settings, State,
+    StateMachine,
 };
 use actix::{Actor, Addr, Arbiter, AsyncContext, Context, Handler, Message, ResponseFuture};
 use slog_scope::info;

--- a/updatehub/src/states/actor/remote_install.rs
+++ b/updatehub/src/states/actor/remote_install.rs
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{DirectDownload, State, StateMachine};
+use actix::{AsyncContext, Context, Handler, Message, MessageResult};
+
+#[derive(Message)]
+#[rtype(Response)]
+pub(crate) struct Request(pub(crate) String);
+
+pub(crate) enum Response {
+    RequestAccepted(String),
+    InvalidState(String),
+}
+
+impl Handler<Request> for super::Machine {
+    type Result = MessageResult<Request>;
+
+    fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
+        if let Some(machine) = &self.state {
+            let res = machine.for_any_state(|s| s.handle_remote_install());
+            return match res {
+                Response::InvalidState(_) => MessageResult(res),
+                Response::RequestAccepted(_) => {
+                    self.stepper.restart(ctx.address());
+                    self.state.replace(StateMachine::DirectDownload(State(DirectDownload {
+                        url: req.0,
+                    })));
+                    MessageResult(res)
+                }
+            };
+        }
+
+        unreachable!("Failed to take StateMachine's ownership");
+    }
+}

--- a/updatehub/src/states/direct_download.rs
+++ b/updatehub/src/states/direct_download.rs
@@ -1,0 +1,59 @@
+// Copyright (C) 2020 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    actor::{self, SharedState},
+    PrepareLocalInstall, Result, State, StateChangeImpl, StateMachine, TransitionError,
+};
+use slog_scope::{debug, error, info};
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, PartialEq)]
+pub(super) struct DirectDownload {
+    pub(super) url: String,
+}
+
+#[async_trait::async_trait]
+impl StateChangeImpl for State<DirectDownload> {
+    fn name(&self) -> &'static str {
+        "direct_download"
+    }
+
+    async fn handle(
+        self,
+        shared_state: &mut SharedState,
+    ) -> Result<(StateMachine, actor::StepTransition)> {
+        info!("Fetching update package directly from url: {:?}", self.0.url);
+
+        let update_file = shared_state.settings.update.download_dir.join("fetched_pkg");
+        let mut response = reqwest::get(&self.0.url).await.map_err(|e| {
+            error!("Request error: {}", e);
+            TransitionError::InvalidRequest
+        })?;
+        let length = response.content_length().ok_or_else(|| {
+            error!("Invalid response: {:?}", response);
+            TransitionError::InvalidRequest
+        })?;
+        let percent = (length / 100) as usize;
+        let mut written: f32 = 0.;
+        let mut threshold = 10;
+        let mut file = tokio::fs::File::create(&update_file).await?;
+        while let Some(chunk) =
+            response.chunk().await.map_err(|_| TransitionError::InvalidRequest)?
+        {
+            file.write_all(&chunk).await?;
+            written += chunk.len() as f32 / percent as f32;
+            if written as usize >= threshold {
+                threshold += 20;
+                debug!("{}% of the file has been downloaded", written as usize);
+            }
+        }
+        debug!("100% of the file has been downloaded");
+
+        Ok((
+            StateMachine::PrepareLocalInstall(State(PrepareLocalInstall { update_file })),
+            actor::StepTransition::Immediate,
+        ))
+    }
+}

--- a/updatehub/src/states/idle.rs
+++ b/updatehub/src/states/idle.rs
@@ -30,6 +30,10 @@ impl StateChangeImpl for State<Idle> {
         actor::local_install::Response::RequestAccepted(self.name().to_owned())
     }
 
+    fn handle_remote_install(&self) -> actor::remote_install::Response {
+        actor::remote_install::Response::RequestAccepted(self.name().to_owned())
+    }
+
     async fn handle(
         self,
         shared_state: &mut SharedState,

--- a/updatehub/src/states/park.rs
+++ b/updatehub/src/states/park.rs
@@ -28,6 +28,10 @@ impl StateChangeImpl for State<Park> {
         actor::local_install::Response::RequestAccepted(self.name().to_owned())
     }
 
+    fn handle_remote_install(&self) -> actor::remote_install::Response {
+        actor::remote_install::Response::RequestAccepted(self.name().to_owned())
+    }
+
     async fn handle(self, _: &mut SharedState) -> Result<(StateMachine, actor::StepTransition)> {
         debug!("Staying on Park state.");
         Ok((StateMachine::Park(self), actor::StepTransition::Never))


### PR DESCRIPTION
We now have a new state on the machine's agent `DirectDownload` that will
download the specified package from the link and will then move to the
`PrepareLocalInstall` state in order to install the required package.
The agent's API now has a new route where the user can request for a package
to be installed from a remote URL which is not an Updatehub Server

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>