### PR TITLE
Update from dev branch

### DIFF
--- a/updatehub-sdk/src/api/mod.rs
+++ b/updatehub-sdk/src/api/mod.rs
@@ -56,10 +56,12 @@ pub mod log {
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "lowercase")]
     pub enum Level {
+        Critical,
         Error,
-        Info,
         Warning,
+        Info,
         Debug,
         Trace,
     }

--- a/updatehub-sdk/src/client/mod.rs
+++ b/updatehub-sdk/src/client/mod.rs
@@ -56,7 +56,7 @@ impl Client {
         let response = self
             .client
             .post(&format!("{}/local_install", self.server_address))
-            .body(format!("{:?}", file))
+            .body(format!("{}", file.display()))
             .send()
             .await?;
 

--- a/updatehub/src/main.rs
+++ b/updatehub/src/main.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use argh::FromArgs;
 use slog_scope::info;
+use std::path::PathBuf;
 
 #[derive(FromArgs)]
 /// Top-level command.
@@ -14,61 +15,71 @@ struct TopLevel {
 #[derive(FromArgs)]
 #[argh(subcommand)]
 enum EntryPoints {
-    Cli(CliOptions),
+    Client(ClientOptions),
     Server(ServerOptions),
 }
 
 #[derive(FromArgs)]
-/// Cli subcommand
-#[argh(subcommand, name = "cli")]
-struct CliOptions {
+/// Client subcommand
+#[argh(subcommand, name = "client")]
+struct ClientOptions {
     #[argh(subcommand)]
-    commands: CliCommands,
+    commands: ClientCommands,
 }
 
 #[derive(FromArgs)]
 #[argh(subcommand)]
-enum CliCommands {
-    Probe(SubCommandProbe),
-    ProbeCustom(SubCommandProbeCustom),
-    Info(SubCommandInfo),
-    Log(SubCommandLog),
-    Abort(SubCommandAbort),
-    Download(SubCommandDownload),
+enum ClientCommands {
+    Info(Info),
+    Log(Log),
+    Probe(Probe),
+    AbortDownload(AbortDownload),
+    LocalInstall(LocalInstall),
+    RemoteInstall(RemoteInstall),
 }
 
 #[derive(FromArgs)]
-/// Probe subcommand
-#[argh(subcommand, name = "probe")]
-struct SubCommandProbe {}
-
-#[derive(FromArgs)]
-/// Info subcommand
+/// Fetches information about the current state of the agent
 #[argh(subcommand, name = "info")]
-struct SubCommandInfo {}
+struct Info {}
 
 #[derive(FromArgs)]
-/// Log subcommand
+/// Fetches the available log entries for the last update cycle
 #[argh(subcommand, name = "log")]
-struct SubCommandLog {}
+struct Log {}
 
 #[derive(FromArgs)]
-/// Abort subcommand
-#[argh(subcommand, name = "abort")]
-struct SubCommandAbort {}
-
-#[derive(FromArgs)]
-/// Download subcommand
-#[argh(subcommand, name = "download")]
-struct SubCommandDownload {}
-
-#[derive(FromArgs)]
-/// Probe custom subcommand
-#[argh(subcommand, name = "probe-custom")]
-struct SubCommandProbeCustom {
+/// Checks if the server has a new update for this device.
+///
+/// A custom server for the update cycle can be specified via the ´--server´
+#[argh(subcommand, name = "probe")]
+struct Probe {
     /// custom address to try probe
+    #[argh(option)]
+    server: Option<String>,
+}
+
+#[derive(FromArgs)]
+/// Abort current running download
+#[argh(subcommand, name = "abort-download")]
+struct AbortDownload {}
+
+#[derive(FromArgs)]
+/// Request agent to install a local update package
+#[argh(subcommand, name = "local-install")]
+struct LocalInstall {
+    /// path to the update package
     #[argh(positional)]
-    server: String,
+    file: PathBuf,
+}
+
+#[derive(FromArgs)]
+/// Request agent to download and install a package from a direct URL
+#[argh(subcommand, name = "remote-install")]
+struct RemoteInstall {
+    /// the URL to get the update package
+    #[argh(positional)]
+    url: String,
 }
 
 #[derive(FromArgs)]
@@ -77,7 +88,7 @@ struct SubCommandProbeCustom {
 struct ServerOptions {
     /// increase the verboseness level
     #[argh(option, short = 'v', from_str_fn(verbosity_level))]
-    verbose: Option<slog::Level>,
+    verbosity: Option<slog::Level>,
 }
 
 fn verbosity_level(value: &str) -> Result<slog::Level, String> {
@@ -86,7 +97,7 @@ fn verbosity_level(value: &str) -> Result<slog::Level, String> {
 }
 
 async fn server_main(cmd: ServerOptions) -> updatehub::Result<()> {
-    updatehub::logger::init(cmd.verbose.unwrap_or(slog::Level::Info));
+    updatehub::logger::init(cmd.verbosity.unwrap_or(slog::Level::Info));
     info!("Starting UpdateHub Agent {}", updatehub::version());
 
     let settings = updatehub::Settings::load()?;
@@ -95,19 +106,23 @@ async fn server_main(cmd: ServerOptions) -> updatehub::Result<()> {
     Ok(())
 }
 
-async fn cli_main(cmd: CliCommands) -> updatehub::Result<()> {
+async fn client_main(cmd: ClientCommands) -> updatehub::Result<()> {
     let client = sdk::Client::new("localhost:8080");
 
-    let res = match cmd {
-        CliCommands::Info(_) => client.info().await,
-        CliCommands::Probe(_) => todo!("probe"),
-        CliCommands::Log(_) => todo!("log"),
-        CliCommands::Abort(_) => todo!("abort"),
-        CliCommands::Download(_) => todo!("Download"),
-        CliCommands::ProbeCustom(input) => todo!("Probe custom {:?}", input.server),
-    };
-
-    dbg!(res).unwrap();
+    match cmd {
+        ClientCommands::Info(_) => println!("{:#?}", client.info().await),
+        ClientCommands::Log(_) => println!("{:#?}", client.log().await),
+        ClientCommands::Probe(Probe { server }) => println!("{:#?}", client.probe(server).await),
+        ClientCommands::AbortDownload(_) => println!("{:#?}", client.abort_download().await),
+        ClientCommands::LocalInstall(LocalInstall { file }) => {
+            let file =
+                if file.is_absolute() { file } else { std::env::current_dir().unwrap().join(file) };
+            println!("{:#?}", client.local_install(file).await)
+        }
+        ClientCommands::RemoteInstall(RemoteInstall { url }) => {
+            println!("{:#?}", client.remote_install(url).await)
+        }
+    }
 
     Ok(())
 }
@@ -117,7 +132,7 @@ async fn main() {
     let cmd: TopLevel = argh::from_env();
 
     let res = match cmd.entry_point {
-        EntryPoints::Cli(cli) => cli_main(cli.commands).await,
+        EntryPoints::Client(client) => client_main(client.commands).await,
         EntryPoints::Server(cmd) => server_main(cmd).await,
     };
 

--- a/updatehub/src/mem_drain.rs
+++ b/updatehub/src/mem_drain.rs
@@ -26,11 +26,8 @@ struct LogRecord {
 }
 
 impl MemDrain {
-    pub fn clear(&self) {
-        self.records.lock().unwrap().clear();
-    }
-
     pub fn start_logging(&mut self) {
+        self.records.lock().unwrap().clear();
         self.logging = true;
     }
 

--- a/updatehub/src/states/actor/local_install.rs
+++ b/updatehub/src/states/actor/local_install.rs
@@ -24,6 +24,7 @@ impl Handler<Request> for super::Machine {
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {
+                    crate::logger::buffer().lock().unwrap().start_logging();
                     self.stepper.restart(ctx.address());
                     self.state.replace(StateMachine::PrepareLocalInstall(State(
                         PrepareLocalInstall { update_file: req.0 },

--- a/updatehub/src/states/actor/remote_install.rs
+++ b/updatehub/src/states/actor/remote_install.rs
@@ -23,6 +23,7 @@ impl Handler<Request> for super::Machine {
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {
+                    crate::logger::buffer().lock().unwrap().start_logging();
                     self.stepper.restart(ctx.address());
                     self.state.replace(StateMachine::DirectDownload(State(DirectDownload {
                         url: req.0,

--- a/updatehub/src/states/install.rs
+++ b/updatehub/src/states/install.rs
@@ -98,9 +98,6 @@ impl StateChangeImpl for State<Install> {
         info!("Swapping active installation set");
 
         info!("Update installed successfully");
-        let buffer = crate::logger::buffer();
-        buffer.lock().unwrap().stop_logging();
-        buffer.lock().unwrap().clear();
         Ok((StateMachine::Reboot(self.into()), actor::StepTransition::Immediate))
     }
 }

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -266,6 +266,7 @@ impl StateMachine {
 /// # }
 /// ```
 pub async fn run(settings: Settings) -> crate::Result<()> {
+    crate::logger::buffer().lock().unwrap().start_logging();
     let listen_socket = settings.network.listen_socket.clone();
     let mut runtime_settings = RuntimeSettings::load(&settings.storage.runtime_settings)?;
     if !settings.storage.read_only {

--- a/updatehub/src/states/park.rs
+++ b/updatehub/src/states/park.rs
@@ -34,6 +34,7 @@ impl StateChangeImpl for State<Park> {
 
     async fn handle(self, _: &mut SharedState) -> Result<(StateMachine, actor::StepTransition)> {
         debug!("Staying on Park state.");
+        crate::logger::buffer().lock().unwrap().stop_logging();
         Ok((StateMachine::Park(self), actor::StepTransition::Never))
     }
 }

--- a/updatehub/src/states/poll.rs
+++ b/updatehub/src/states/poll.rs
@@ -28,6 +28,7 @@ impl StateChangeImpl for State<Poll> {
         self,
         shared_state: &mut SharedState,
     ) -> Result<(StateMachine, actor::StepTransition)> {
+        crate::logger::buffer().lock().unwrap().start_logging();
         let current_time: DateTime<Utc> = Utc::now();
 
         if shared_state.runtime_settings.is_polling_forced() {

--- a/updatehub/src/states/prepare_download.rs
+++ b/updatehub/src/states/prepare_download.rs
@@ -34,7 +34,6 @@ impl StateChangeImpl for State<PrepareDownload> {
         self,
         shared_state: &mut SharedState,
     ) -> Result<(StateMachine, actor::StepTransition)> {
-        crate::logger::buffer().lock().unwrap().start_logging();
         let installation_set = installation_set::inactive()?;
         let download_dir = shared_state.settings.update.download_dir.to_owned();
 

--- a/updatehub/src/states/prepare_local_install.rs
+++ b/updatehub/src/states/prepare_local_install.rs
@@ -27,6 +27,7 @@ impl StateChangeImpl for State<PrepareLocalInstall> {
     ) -> Result<(StateMachine, actor::StepTransition)> {
         info!("Prepare local install: {:?}", self.0.update_file);
         let dest_path = shared_state.settings.update.download_dir.clone();
+        std::fs::create_dir_all(&dest_path)?;
         compress_tools::uncompress(self.0.update_file, &dest_path, compress_tools::Kind::Zip)?;
         debug!("Successfuly uncompressed the update package");
 

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -31,6 +31,7 @@ impl StateChangeImpl for State<Probe> {
         self,
         shared_state: &mut SharedState,
     ) -> Result<(StateMachine, actor::StepTransition)> {
+        crate::logger::buffer().lock().unwrap().start_logging();
         let server_address = shared_state.server_address();
 
         let probe = match Api::new(&server_address)


### PR DESCRIPTION
* Renamed `cli` subcommand to `client`;
* Finished client subcommands;
* Fixed some api specifications on SDK;
* Fixed directory creation for `prepare_local_install` state;
* Reworked points where buffered log gets started and cleared so user queries are more informative;