### PR TITLE
updatehub: Avoid explicit locking of logger buffer

### DIFF
--- a/updatehub/src/logger.rs
+++ b/updatehub/src/logger.rs
@@ -29,3 +29,15 @@ pub fn init(level: slog::Level) {
 pub fn buffer() -> Arc<Mutex<MemDrain>> {
     BUFFER.clone()
 }
+
+pub fn start_memory_logging() {
+    BUFFER.lock().unwrap().start_logging()
+}
+
+pub fn stop_memory_logging() {
+    BUFFER.lock().unwrap().stop_logging()
+}
+
+pub fn get_memory_log() -> String {
+    BUFFER.lock().unwrap().to_string()
+}

--- a/updatehub/src/states/actor/local_install.rs
+++ b/updatehub/src/states/actor/local_install.rs
@@ -24,7 +24,7 @@ impl Handler<Request> for super::Machine {
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {
-                    crate::logger::buffer().lock().unwrap().start_logging();
+                    crate::logger::start_memory_logging();
                     self.stepper.restart(ctx.address());
                     self.state.replace(StateMachine::PrepareLocalInstall(State(
                         PrepareLocalInstall { update_file: req.0 },

--- a/updatehub/src/states/actor/remote_install.rs
+++ b/updatehub/src/states/actor/remote_install.rs
@@ -23,7 +23,7 @@ impl Handler<Request> for super::Machine {
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {
-                    crate::logger::buffer().lock().unwrap().start_logging();
+                    crate::logger::start_memory_logging();
                     self.stepper.restart(ctx.address());
                     self.state.replace(StateMachine::DirectDownload(State(DirectDownload {
                         url: req.0,

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -173,7 +173,7 @@ where
                     "error",
                     Some(enter_state),
                     Some(e.to_string()),
-                    Some(crate::logger::buffer().lock().unwrap().to_string()),
+                    Some(crate::logger::get_memory_log()),
                 )
                 .await
                 {
@@ -266,7 +266,7 @@ impl StateMachine {
 /// # }
 /// ```
 pub async fn run(settings: Settings) -> crate::Result<()> {
-    crate::logger::buffer().lock().unwrap().start_logging();
+    crate::logger::start_memory_logging();
     let listen_socket = settings.network.listen_socket.clone();
     let mut runtime_settings = RuntimeSettings::load(&settings.storage.runtime_settings)?;
     if !settings.storage.read_only {

--- a/updatehub/src/states/park.rs
+++ b/updatehub/src/states/park.rs
@@ -34,7 +34,7 @@ impl StateChangeImpl for State<Park> {
 
     async fn handle(self, _: &mut SharedState) -> Result<(StateMachine, actor::StepTransition)> {
         debug!("Staying on Park state.");
-        crate::logger::buffer().lock().unwrap().stop_logging();
+        crate::logger::stop_memory_logging();
         Ok((StateMachine::Park(self), actor::StepTransition::Never))
     }
 }

--- a/updatehub/src/states/poll.rs
+++ b/updatehub/src/states/poll.rs
@@ -28,7 +28,7 @@ impl StateChangeImpl for State<Poll> {
         self,
         shared_state: &mut SharedState,
     ) -> Result<(StateMachine, actor::StepTransition)> {
-        crate::logger::buffer().lock().unwrap().start_logging();
+        crate::logger::start_memory_logging();
         let current_time: DateTime<Utc> = Utc::now();
 
         if shared_state.runtime_settings.is_polling_forced() {

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -31,7 +31,6 @@ impl StateChangeImpl for State<Probe> {
         self,
         shared_state: &mut SharedState,
     ) -> Result<(StateMachine, actor::StepTransition)> {
-        crate::logger::buffer().lock().unwrap().start_logging();
         let server_address = shared_state.server_address();
 
         let probe = match Api::new(&server_address)


### PR DESCRIPTION
This also removes the 'start_logging' on probe state, as it is already started on http requests and on polling state