### PR TITLE
updatehub: Add test to ensure fail on custom probe to invalid url

### DIFF
--- a/updatehub/src/states/actor/mod.rs
+++ b/updatehub/src/states/actor/mod.rs
@@ -81,6 +81,7 @@ impl Machine {
 #[rtype(StepTransition)]
 struct Step;
 
+#[derive(Debug)]
 pub(crate) enum StepTransition {
     Delayed(std::time::Duration),
     Immediate,


### PR DESCRIPTION
Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>