### PR TITLE
Convert error types to thiserror crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "slog-term 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-mount 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "timeout-readwrite 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2249,10 +2250,10 @@ name = "updatehub-sdk"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.99.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse_duration 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/updatehub-sdk/Cargo.toml
+++ b/updatehub-sdk/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-derive_more = "0.99"
 parse_duration = "2"
 reqwest = { version = "0.10", features = ["default-tls", "json"] }
 serde = { version = "1", features = ["derive"] }
+thiserror = "1"

--- a/updatehub-sdk/src/client/mod.rs
+++ b/updatehub-sdk/src/client/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{api, Result};
+use crate::{api, Error, Result};
 use std::path::PathBuf;
 
 #[derive(Clone)]
@@ -30,7 +30,7 @@ impl Client {
 
         match response.status() {
             reqwest::StatusCode::OK => Ok(response.json().await?),
-            _ => Err(response.into()),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -46,9 +46,9 @@ impl Client {
         match response.status() {
             reqwest::StatusCode::OK => Ok(response.json().await?),
             reqwest::StatusCode::ACCEPTED => {
-                Err(response.json::<api::state::Response>().await?.into())
+                Err(Error::AgentIsBusy(response.json::<api::state::Response>().await?))
             }
-            _ => Err(response.into()),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -63,9 +63,9 @@ impl Client {
         match response.status() {
             reqwest::StatusCode::OK => Ok(response.json().await?),
             reqwest::StatusCode::UNPROCESSABLE_ENTITY => {
-                Err(response.json::<api::state::Response>().await?.into())
+                Err(Error::AgentIsBusy(response.json::<api::state::Response>().await?))
             }
-            _ => Err(response.into()),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -80,9 +80,9 @@ impl Client {
         match response.status() {
             reqwest::StatusCode::OK => Ok(response.json().await?),
             reqwest::StatusCode::UNPROCESSABLE_ENTITY => {
-                Err(response.json::<api::state::Response>().await?.into())
+                Err(Error::AgentIsBusy(response.json::<api::state::Response>().await?))
             }
-            _ => Err(response.into()),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -95,10 +95,10 @@ impl Client {
 
         match response.status() {
             reqwest::StatusCode::OK => Ok(response.json().await?),
-            reqwest::StatusCode::BAD_REQUEST => {
-                Err(response.json::<api::abort_download::Refused>().await?.into())
-            }
-            _ => Err(response.into()),
+            reqwest::StatusCode::BAD_REQUEST => Err(Error::AbortDownloadRefused(
+                response.json::<api::abort_download::Refused>().await?,
+            )),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 
@@ -107,7 +107,7 @@ impl Client {
 
         match response.status() {
             reqwest::StatusCode::OK => Ok(response.json().await?),
-            _ => Err(response.into()),
+            _ => Err(Error::UnexpectedResponse(response)),
         }
     }
 }

--- a/updatehub-sdk/src/error.rs
+++ b/updatehub-sdk/src/error.rs
@@ -2,18 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use derive_more::{Display, From};
+use thiserror::Error;
 
 pub type Result<A> = std::result::Result<A, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "Agent is busy: {:?}", _0)]
+    #[error("Agent is busy: {0:?}")]
     AgentIsBusy(crate::api::state::Response),
-    #[display(fmt = "Abort download was refused: {:?}", _0)]
+
+    #[error("Abort download was refused: {0:?}")]
     AbortDownloadRefused(crate::api::abort_download::Refused),
 
-    #[display(fmt = "Unexpected response: {:?}", _0)]
+    #[error("Unexpected response: {0:?}")]
     UnexpectedResponse(reqwest::Response),
-    ClientError(reqwest::Error),
+
+    #[error("Client error: {0}")]
+    ClientError(#[from] reqwest::Error),
 }

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 compress-tools = { git = "https://github.com/OSSystems/compress-tools-rs.git" }
 crypto-hash = "0.3"
-derive_more = "0.99"
+derive_more = { version = "0.99", default-features = false, features = ["deref", "deref_mut"] }
 easy_process = "0.1"
 hex = "0.4"
 infer = "0.1"
@@ -39,6 +39,7 @@ slog-scope = "4"
 slog-term = "2"
 sys-mount = "1"
 tempfile = "3"
+thiserror = "1"
 timeout-readwrite = "0.3"
 tokio = { version = "0.2", features = ["fs"] }
 toml = "0.5"

--- a/updatehub/src/http_api.rs
+++ b/updatehub/src/http_api.rs
@@ -4,18 +4,18 @@
 
 use crate::states::actor;
 use actix_web::{http::StatusCode, web, HttpRequest, HttpResponse, Responder};
-use derive_more::{Display, From};
 use sdk::api;
 use slog_scope::debug;
+use thiserror::Error;
 
 pub(crate) struct API(actix::Addr<actor::Machine>);
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "Mailbox error: {}", _0)]
-    ActixMailbox(actix::MailboxError),
+    #[error("Mailbox error: {0}")]
+    ActixMailbox(#[from] actix::MailboxError),
 }
 
 impl API {

--- a/updatehub/src/lib.rs
+++ b/updatehub/src/lib.rs
@@ -19,24 +19,24 @@ mod update_package;
 mod utils;
 
 pub use crate::{build_info::version, settings::Settings, states::run};
-use derive_more::{Display, From};
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "Update package error: {}", _0)]
-    UpdatePackage(crate::update_package::Error),
-    #[display(fmt = "Runtime settings error: {}", _0)]
-    RuntimeSettings(crate::runtime_settings::Error),
-    #[display(fmt = "Settings error: {}", _0)]
-    Settings(crate::settings::Error),
-    #[display(fmt = "Firmware error: {}", _0)]
-    Firmware(crate::firmware::Error),
-    #[display(fmt = "Client error: {}", _0)]
-    Client(crate::client::Error),
-    #[display(fmt = "Io error: {}", _0)]
-    Io(std::io::Error),
-    #[display(fmt = "Process error: {}", _0)]
-    Process(easy_process::Error),
+    #[error("Runtime settings error: {0}")]
+    RuntimeSettings(#[from] crate::runtime_settings::Error),
+
+    #[error("Settings error: {0}")]
+    Settings(#[from] crate::settings::Error),
+
+    #[error("Firmware error: {0}")]
+    Firmware(#[from] crate::firmware::Error),
+
+    #[error("Io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Process error: {0}")]
+    Process(#[from] easy_process::Error),
 }

--- a/updatehub/src/object/mod.rs
+++ b/updatehub/src/object/mod.rs
@@ -10,21 +10,24 @@ pub(crate) mod installer;
 
 pub(crate) use self::{info::Info, installer::Installer};
 
-use derive_more::{Display, From};
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "Invalid path formed")]
+    #[error("Invalid path formed")]
     InvalidPath,
-    #[display(fmt = "Unsupported target type: {:?}", _0)]
+
+    #[error("Unsupported target type: {0:?}")]
     InvalidTargetType(pkg_schema::definitions::TargetType),
 
-    #[display(fmt = "Utils error: {}", _0)]
-    Utils(crate::utils::Error),
-    #[display(fmt = "Io error: {}", _0)]
-    Io(std::io::Error),
-    #[display(fmt = "Process error: {}", _0)]
-    Process(easy_process::Error),
+    #[error("Utils error: {0}")]
+    Utils(#[from] crate::utils::Error),
+
+    #[error("Io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Process error: {0}")]
+    Process(#[from] easy_process::Error),
 }

--- a/updatehub/src/runtime_settings.rs
+++ b/updatehub/src/runtime_settings.rs
@@ -4,25 +4,27 @@
 
 use crate::firmware::installation_set::Set;
 use chrono::{DateTime, Duration, Utc};
-use derive_more::{Deref, DerefMut, Display, From};
+use derive_more::{Deref, DerefMut};
 use sdk::api::info::runtime_settings as api;
 use slog_scope::debug;
 use std::{fs, io, path::Path};
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "IO error: {}", _0)]
-    Io(io::Error),
-    #[display(fmt = "Fail with serialization/deserialization: {}", _0)]
-    SerdeJson(serde_json::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
 
-    #[display(fmt = "Invalid runtime settings destination")]
+    #[error("Fail with serialization/deserialization: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+
+    #[error("Invalid runtime settings destination")]
     InvalidDestination,
 }
 
-#[derive(Debug, Deref, DerefMut, From, PartialEq)]
+#[derive(Debug, Deref, DerefMut, PartialEq)]
 pub(crate) struct RuntimeSettings(pub(crate) api::RuntimeSettings);
 
 impl Default for RuntimeSettings {

--- a/updatehub/src/settings.rs
+++ b/updatehub/src/settings.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chrono::Duration;
-use derive_more::{Deref, DerefMut, Display, From};
+use derive_more::{Deref, DerefMut};
 use slog_scope::{debug, error};
 use std::{fs, io};
+use thiserror::Error;
 
 const SYSTEM_SETTINGS_PATH: &str = "/etc/updatehub.conf";
 
@@ -13,21 +14,21 @@ pub use sdk::api::info::settings as api;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "IO error: {}", _0)]
-    Io(io::Error),
-    #[display(fmt = "Fail reading the file: {}", _0)]
-    Deserialize(toml::de::Error),
-    #[display(fmt = "Fail generating the file: {}", _0)]
-    Serialize(toml::ser::Error),
-    #[display(fmt = "Invalid interval")]
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    #[error("Fail reading the file: {0}")]
+    Deserialize(#[from] toml::de::Error),
+    #[error("Fail generating the file: {0}")]
+    Serialize(#[from] toml::ser::Error),
+    #[error("Invalid interval")]
     InvalidInterval,
-    #[display(fmt = "Invalid server address")]
+    #[error("Invalid server address")]
     InvalidServerAddress,
 }
 
-#[derive(Clone, Debug, Deref, DerefMut, From, PartialEq)]
+#[derive(Clone, Debug, Deref, DerefMut, PartialEq)]
 pub struct Settings(pub api::Settings);
 
 impl Default for Settings {

--- a/updatehub/src/states/prepare_local_install.rs
+++ b/updatehub/src/states/prepare_local_install.rs
@@ -28,7 +28,8 @@ impl StateChangeImpl for State<PrepareLocalInstall> {
         info!("Prepare local install: {:?}", self.0.update_file);
         let dest_path = shared_state.settings.update.download_dir.clone();
         std::fs::create_dir_all(&dest_path)?;
-        compress_tools::uncompress(self.0.update_file, &dest_path, compress_tools::Kind::Zip)?;
+        compress_tools::uncompress(self.0.update_file, &dest_path, compress_tools::Kind::Zip)
+            .map_err(super::TransitionError::Uncompress)?;
         debug!("Successfuly uncompressed the update package");
 
         let metadata = io::BufReader::new(fs::File::open(dest_path.join("metadata"))?);

--- a/updatehub/src/update_package/mod.rs
+++ b/updatehub/src/update_package/mod.rs
@@ -12,10 +12,10 @@ use walkdir::WalkDir;
 
 use crypto_hash::{hex_digest, Algorithm};
 
-use derive_more::{Display, From};
 use pkg_schema::Object;
 use serde::Deserialize;
 use slog_scope::error;
+use thiserror::Error;
 
 use std::{fs, io, path::Path};
 
@@ -46,13 +46,12 @@ pub(crate) struct UpdatePackage {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "Json parsing error: {}", _0)]
-    JsonParsing(serde_json::Error),
+    #[error("Json parsing error: {0}")]
+    JsonParsing(#[from] serde_json::Error),
 
-    #[display(fmt = "Incompatible with hardware: {}", _0)]
-    #[from(ignore)]
+    #[error("Incompatible with hardware: {0}")]
     IncompatibleHardware(String),
 }
 

--- a/updatehub/src/utils/mod.rs
+++ b/updatehub/src/utils/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use derive_more::{Display, From};
+use thiserror::Error;
 
 pub(crate) mod definitions;
 pub(crate) mod fs;
@@ -11,36 +11,41 @@ pub(crate) mod mtd;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Display, From)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[display(fmt = "Io: {}", _0)]
-    Io(std::io::Error),
-    #[display(fmt = "Nix error: {}", _0)]
-    Nix(nix::Error),
-    #[display(fmt = "Uncompress error")]
-    Uncompress,
-    #[display(fmt = "Process error: {}", _0)]
-    Process(easy_process::Error),
-    #[display(fmt = "Strip prefix error: {}", _0)]
-    StripPrefix(std::path::StripPrefixError),
+    #[error("Io: {0}")]
+    Io(#[from] std::io::Error),
 
-    #[display(fmt = "Target device does not exists")]
+    #[error("Nix error: {0}")]
+    Nix(#[from] nix::Error),
+
+    #[error("Uncompress error")]
+    Uncompress,
+
+    #[error("Process error: {0}")]
+    Process(#[from] easy_process::Error),
+
+    #[error("Strip prefix error: {0}")]
+    StripPrefix(#[from] std::path::StripPrefixError),
+
+    #[error("Target device does not exists")]
     DeviceDoesNotExist,
-    #[display(fmt = "User doesn't have write permission on target device: {:?}", _0)]
-    #[from(ignore)]
+
+    #[error("User doesn't have write permission on target device: {0}")]
     MissingWritePermission(std::path::PathBuf),
-    #[display(fmt = "Unknown file type")]
+
+    #[error("Unknown file type")]
     UknownFileType,
-    #[display(fmt = "{} is not a valid archive type", _0)]
-    #[from(ignore)]
+
+    #[error("{0} is not a valid archive type")]
     InvalidFileType(String),
-    #[display(fmt = "'{}' not found on PATH", _0)]
-    #[from(ignore)]
+
+    #[error("'{0}' not found on PATH")]
     ExecutableNotInPath(String),
-    #[display(fmt = "Unable to find Ubi Volume: {}", _0)]
-    #[from(ignore)]
+
+    #[error("Unable to find Ubi Volume: {0}")]
     NoUbiVolume(String),
-    #[display(fmt = "Unable to find match for mtd device: {}", _0)]
-    #[from(ignore)]
+
+    #[error("Unable to find match for mtd device: {0}")]
     NoMtdDevice(String),
 }


### PR DESCRIPTION
The use of thiserror allow us to properly implement std::error::Error
and better use the ecosystem.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>