### PR TITLE
updatehub: Use install_if_different rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-binary-version"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2158,7 @@ dependencies = [
  "crypto-hash 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy_process 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "find-binary-version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "infer 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2497,6 +2508,7 @@ dependencies = [
 "checksum extend 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf29866f640a891350d1aa695e0bf254df007df909cbecb65f6db4ba593b70a8"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+"checksum find-binary-version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "39d6cd9f176ca8fc4902eeee2e718c50ad5a014128616b1c5d6ce5f18c197289"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -20,6 +20,7 @@ compress-tools = { git = "https://github.com/OSSystems/compress-tools-rs.git" }
 crypto-hash = "0.3"
 derive_more = { version = "0.99", default-features = false, features = ["deref", "deref_mut"] }
 easy_process = "0.1"
+find-binary-version = "0.2"
 hex = "0.4"
 infer = "0.1"
 lazy_static = "1"

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -31,7 +31,7 @@ impl Installer for objects::Copy {
     }
 
     fn install(&self, download_dir: &Path) -> Result<()> {
-        info!("'copy' handler Install");
+        info!("'copy' handler Install {} ({})", self.filename, self.sha256sum);
 
         let device = self.target_type.get_target()?;
         let filesystem = self.filesystem;

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -84,6 +84,7 @@ impl Installer for objects::Copy {
             Ok(())
         })
         .map_err(Error::from)
+        .and_then(|r| r)
     }
 }
 
@@ -147,8 +148,8 @@ mod tests {
 
                 utils::fs::chown(&file, &perm.target_uid, &perm.target_gid)?;
 
-                Ok(())
-            })?;
+                utils::Result::Ok(())
+            })??;
         }
 
         // Generate base copy object
@@ -212,8 +213,8 @@ mod tests {
                 assert_eq!(gid, metadata.gid());
             };
 
-            Ok(())
-        })?;
+            std::io::Result::Ok(())
+        })??;
 
         loopdev.detach()?;
 

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -42,6 +42,14 @@ impl Installer for objects::Copy {
         let target_path = self.target_path.strip_prefix("/").unwrap_or(&self.target_path);
         let source = download_dir.join(sha256sum);
 
+        handle_install_if_different!(self.install_if_different, sha256sum, {
+            utils::fs::mount_map(&device, filesystem, mount_options, |path| {
+                fs::File::open(&path.join(&target_path)).map_err(Error::from)
+            })
+            .map_err(Error::from)
+            .and_then(|r| r)
+        });
+
         if self.target_format.should_format {
             utils::fs::format(&device, filesystem, &format_options)?;
         }

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -28,7 +28,7 @@ impl Installer for objects::Flash {
     }
 
     fn install(&self, download_dir: &std::path::Path) -> Result<()> {
-        info!("'flash' handler Install");
+        info!("'flash' handler Install {} ({})", self.filename, self.sha256sum);
 
         let target = self.target.get_target()?;
         let source = download_dir.join(self.sha256sum());

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -32,6 +32,11 @@ impl Installer for objects::Flash {
 
         let target = self.target.get_target()?;
         let source = download_dir.join(self.sha256sum());
+
+        handle_install_if_different!(self.install_if_different, &self.sha256sum, {
+            std::fs::File::open(&target).map_err(Error::from)
+        });
+
         let is_nand = utils::mtd::is_nand(&target)?;
 
         easy_process::run(&format!("flash_erase {:?} 0 0", target))?;

--- a/updatehub/src/object/installer/imxkobs.rs
+++ b/updatehub/src/object/installer/imxkobs.rs
@@ -19,7 +19,8 @@ impl Installer for objects::Imxkobs {
     }
 
     fn install(&self, download_dir: &std::path::Path) -> Result<()> {
-        info!("'imxkobs' handler Install");
+        info!("'imxkobs' handler Install {} ({})", self.filename, self.sha256sum);
+
         let mut cmd = String::from("kobs-ng init ");
 
         if self.padding_1k {

--- a/updatehub/src/object/installer/raw.rs
+++ b/updatehub/src/object/installer/raw.rs
@@ -34,7 +34,7 @@ impl Installer for objects::Raw {
     }
 
     fn install(&self, download_dir: &Path) -> Result<()> {
-        info!("'raw' handler Install");
+        info!("'raw' handler Install {} ({})", self.filename, self.sha256sum);
 
         let device = match self.target_type {
             definitions::TargetType::Device(ref p) => p,

--- a/updatehub/src/object/installer/raw.rs
+++ b/updatehub/src/object/installer/raw.rs
@@ -47,6 +47,18 @@ impl Installer for objects::Raw {
         let truncate = self.truncate.0;
         let count = self.count.clone();
 
+        handle_install_if_different!(self.install_if_different, &self.sha256sum, {
+            fs::OpenOptions::new()
+                .read(true)
+                .open(device)
+                .map(|h| utils::io::timed_buf_reader(chunk_size, h))
+                .and_then(|mut h| {
+                    h.seek(SeekFrom::Start(seek))?;
+                    Ok(h)
+                })
+                .map_err(Error::from)
+        });
+
         if self.compressed {
             unimplemented!("FIXME: handle compressed installation");
         } else {

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -29,7 +29,7 @@ impl Installer for objects::Tarball {
     }
 
     fn install(&self, download_dir: &Path) -> Result<()> {
-        info!("'tarball' handler Install");
+        info!("'tarball' handler Install {} ({})", self.filename, self.sha256sum);
 
         let device = self.target.get_target()?;
         let filesystem = self.filesystem;

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -52,7 +52,7 @@ impl Installer for objects::Tarball {
                 utils::fs::find_compress_tarball_kind(&source)?,
             )
             .map_err(|_| crate::utils::Error::Uncompress)
-        })?)
+        })??)
     }
 }
 
@@ -114,8 +114,8 @@ mod tests {
         // Setup preinstall structure
         utils::fs::mount_map(&device, definitions::Filesystem::Ext4, &"", |path| {
             fs::create_dir(path.join("existing_dir"))?;
-            Ok(())
-        })?;
+            utils::Result::Ok(())
+        })??;
 
         // Peform Install
         obj.check_requirements()?;
@@ -136,8 +136,8 @@ mod tests {
             assert_metadata(&dest.join("tree/branch1/leaf"))?;
             assert_metadata(&dest.join("tree/branch2/leaf"))?;
 
-            Ok(())
-        })?;
+            utils::Result::Ok(())
+        })??;
 
         loopdev.detach()?;
 

--- a/updatehub/src/object/installer/ubifs.rs
+++ b/updatehub/src/object/installer/ubifs.rs
@@ -29,7 +29,7 @@ impl Installer for objects::Ubifs {
     }
 
     fn install(&self, download_dir: &std::path::Path) -> Result<()> {
-        info!("'ubifs' handler Install");
+        info!("'ubifs' handler Install {} ({})", self.filename, self.sha256sum);
 
         let target = self.target.get_target()?;
         let source = download_dir.join(self.sha256sum());

--- a/updatehub/src/utils/fs.rs
+++ b/updatehub/src/utils/fs.rs
@@ -69,9 +69,9 @@ pub(crate) fn format(target: &Path, fs: Filesystem, options: &Option<String>) ->
     Ok(())
 }
 
-pub(crate) fn mount_map<F>(source: &Path, fs: Filesystem, options: &str, f: F) -> Result<()>
+pub(crate) fn mount_map<F, T>(source: &Path, fs: Filesystem, options: &str, f: F) -> Result<T>
 where
-    F: FnOnce(&Path) -> Result<()>,
+    F: FnOnce(&Path) -> T,
 {
     let tmpdir = tempfile::tempdir()?;
     let tmpdir = tmpdir.path();
@@ -80,7 +80,7 @@ where
     // closure is run.
     let _guard = mount(source, &tmpdir, fs, options)?;
 
-    f(tmpdir)
+    Ok(f(tmpdir))
 }
 
 pub(crate) fn mount(


### PR DESCRIPTION
Add check_if_different helper function to object::installer module. Function is
used on install modes that support install_if_different rule so we can skip
installation if requested

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>