### PR TITLE
Remove use of crypto-hash and hex crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,22 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "commoncrypto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "commoncrypto-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "compress-tools"
 version = "0.2.1-alpha.0"
 source = "git+https://github.com/OSSystems/compress-tools-rs.git#29da4365bc59b551f92a7a72c4a38848476dae42"
@@ -637,17 +621,6 @@ dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crypto-hash"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -993,16 +966,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hostname"
@@ -2155,12 +2118,10 @@ dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "compress-tools 0.2.1-alpha.0 (git+https://github.com/OSSystems/compress-tools-rs.git)",
- "crypto-hash 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "easy_process 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "find-binary-version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-version 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "infer 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "loopdev 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2480,8 +2441,6 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmdline_words_parser 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f82d4d9b75a0a6f8423e5d2b4572f35da7fe3fb196df01b335a4a66342109ea"
 "checksum colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8815e2ab78f3a59928fc32e141fbeece88320a240e43f47b2fd64ea3a88a5b3d"
-"checksum commoncrypto 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
-"checksum commoncrypto-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 "checksum compress-tools 0.2.1-alpha.0 (git+https://github.com/OSSystems/compress-tools-rs.git)" = "<none>"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff9c56c9fb2a49c05ef0e431485a22400af20d33226dc0764d891d09e724127"
@@ -2492,7 +2451,6 @@ dependencies = [
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
-"checksum crypto-hash 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
 "checksum ctor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
 "checksum derive_more 0.99.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a806e96c59a76a5ba6e18735b6cf833344671e61e7863f2edb5c518ea2cac95c"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
@@ -2532,8 +2490,6 @@ dependencies = [
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
-"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-"checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -17,11 +17,9 @@ argh = "0.1.3"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 compress-tools = { git = "https://github.com/OSSystems/compress-tools-rs.git" }
-crypto-hash = "0.3"
 derive_more = { version = "0.99", default-features = false, features = ["deref", "deref_mut"] }
 easy_process = "0.1"
 find-binary-version = "0.2"
-hex = "0.4"
 infer = "0.1"
 lazy_static = "1"
 ms-converter = "0.5"

--- a/updatehub/src/object/installer/mod.rs
+++ b/updatehub/src/object/installer/mod.rs
@@ -11,7 +11,7 @@ mod test;
 mod ubifs;
 
 use super::{Error, Result};
-use crypto_hash::{hex_digest, Algorithm};
+use crate::utils;
 use find_binary_version::{self as fbv, BinaryKind};
 use pkg_schema::{definitions, Object};
 use slog_scope::debug;
@@ -63,8 +63,7 @@ fn check_if_different<R: io::Read + io::Seek>(
         definitions::InstallIfDifferent::CheckSum => {
             let mut buffer = Vec::default();
             handle.read_to_end(&mut buffer)?;
-            let calculated = &hex_digest(Algorithm::SHA256, &buffer);
-            if calculated == sha256sum {
+            if utils::sha256sum(&buffer) == sha256sum {
                 return Ok(true);
             }
         }

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -106,8 +106,8 @@ mod test {
         runtime_settings::RuntimeSettings,
         states::PrepareDownload,
         update_package::tests::{create_fake_settings, get_update_package_with_shasum},
+        utils,
     };
-    use crypto_hash::{hex_digest, Algorithm};
     use mockito::mock;
     use pretty_assertions::assert_eq;
     use std::{
@@ -119,7 +119,7 @@ mod test {
 
     fn fake_download_object(size: usize) -> (Vec<u8>, String) {
         let vec = std::iter::repeat(0xF).take(size).collect::<Vec<_>>();
-        let shasum = hex_digest(Algorithm::SHA256, &vec);
+        let shasum = utils::sha256sum(&vec);
         (vec, shasum)
     }
 
@@ -194,11 +194,7 @@ mod test {
             .expect("Fail to open the temporary directory.")
             .read_to_string(&mut object_content);
 
-        assert_eq!(
-            &hex_digest(Algorithm::SHA256, object_content.as_bytes()),
-            &shasum,
-            "Checksum mismatch"
-        );
+        assert_eq!(&utils::sha256sum(&object_content.as_bytes()), &shasum, "Checksum mismatch");
     }
 
     #[actix_rt::test]

--- a/updatehub/src/update_package/mod.rs
+++ b/updatehub/src/update_package/mod.rs
@@ -6,16 +6,14 @@ use crate::{
     firmware::{installation_set::Set, Metadata},
     object::{self, Info},
     settings::Settings,
+    utils,
 };
-use sdk::api::info::runtime_settings::InstallationSet;
-use walkdir::WalkDir;
-
-use crypto_hash::{hex_digest, Algorithm};
-
 use pkg_schema::Object;
+use sdk::api::info::runtime_settings::InstallationSet;
 use serde::Deserialize;
 use slog_scope::error;
 use thiserror::Error;
+use walkdir::WalkDir;
 
 use std::{fs, io, path::Path};
 
@@ -81,7 +79,7 @@ impl UpdatePackage {
     }
 
     pub(crate) fn package_uid(&self) -> String {
-        hex_digest(Algorithm::SHA256, &self.raw)
+        utils::sha256sum(&self.raw)
     }
 
     pub(crate) fn compatible_with(&self, firmware: &Metadata) -> Result<()> {

--- a/updatehub/src/utils/mod.rs
+++ b/updatehub/src/utils/mod.rs
@@ -49,3 +49,13 @@ pub enum Error {
     #[error("Unable to find match for mtd device: {0}")]
     NoMtdDevice(String),
 }
+
+/// Encode a bytes stream in hex
+pub(crate) fn hex_encode(data: &[u8]) -> String {
+    data.iter().map(|c| format!("{:02x}", c)).collect()
+}
+
+/// Get sha256sum hash from a byte stream
+pub(crate) fn sha256sum(data: &[u8]) -> String {
+    hex_encode(&openssl::sha::sha256(data))
+}


### PR DESCRIPTION
We are using the OpenSSL anyway and it can be used to do the sha256sum,
so we are dropping the crypto-hash crate which were used for this.

While doing that, we found that converting to hex is simple enough so we
also dropped hex use as well.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>