### PR TITLE
updatehub: Rework trigger probe request

### DIFF
--- a/updatehub-sdk/src/api/mod.rs
+++ b/updatehub-sdk/src/api/mod.rs
@@ -15,7 +15,8 @@ pub mod probe {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct Response {
         pub update_available: bool,
-        pub try_again_in: i32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub try_again_in: Option<i64>,
     }
 }
 

--- a/updatehub/src/http_api.rs
+++ b/updatehub/src/http_api.rs
@@ -10,10 +10,10 @@ use thiserror::Error;
 
 pub(crate) struct API(actix::Addr<actor::Machine>);
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(crate) enum Error {
     #[error("Mailbox error: {0}")]
     ActixMailbox(#[from] actix::MailboxError),
 }

--- a/updatehub/src/states/actor/download_abort.rs
+++ b/updatehub/src/states/actor/download_abort.rs
@@ -19,14 +19,12 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, _: Request, _: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let res = machine.for_current_state(|s| s.handle_download_abort());
-            return match res {
-                Response::InvalidState => MessageResult(res),
-                Response::RequestAccepted => {
-                    self.state.replace(StateMachine::EntryPoint(State(EntryPoint {})));
-                    MessageResult(res)
-                }
-            };
+            if machine.for_current_state(|s| s.can_run_download_abort()) {
+                self.state.replace(StateMachine::EntryPoint(State(EntryPoint {})));
+                return MessageResult(Response::RequestAccepted);
+            }
+
+            return MessageResult(Response::InvalidState);
         }
 
         unreachable!("Failed to take StateMachine's ownership");

--- a/updatehub/src/states/actor/download_abort.rs
+++ b/updatehub/src/states/actor/download_abort.rs
@@ -18,15 +18,13 @@ impl Handler<Request> for super::Machine {
     type Result = MessageResult<Request>;
 
     fn handle(&mut self, _: Request, _: &mut Context<Self>) -> Self::Result {
-        if let Some(machine) = &self.state {
-            if machine.for_current_state(|s| s.can_run_download_abort()) {
-                self.state.replace(StateMachine::EntryPoint(State(EntryPoint {})));
-                return MessageResult(Response::RequestAccepted);
-            }
+        let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
 
-            return MessageResult(Response::InvalidState);
+        if machine.for_current_state(|s| s.can_run_download_abort()) {
+            self.state.replace(StateMachine::EntryPoint(State(EntryPoint {})));
+            return MessageResult(Response::RequestAccepted);
         }
 
-        unreachable!("Failed to take StateMachine's ownership");
+        MessageResult(Response::InvalidState)
     }
 }

--- a/updatehub/src/states/actor/download_abort.rs
+++ b/updatehub/src/states/actor/download_abort.rs
@@ -19,7 +19,7 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, _: Request, _: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let res = machine.for_any_state(|s| s.handle_download_abort());
+            let res = machine.for_current_state(|s| s.handle_download_abort());
             return match res {
                 Response::InvalidState => MessageResult(res),
                 Response::RequestAccepted => {

--- a/updatehub/src/states/actor/info.rs
+++ b/updatehub/src/states/actor/info.rs
@@ -14,17 +14,14 @@ impl Handler<Request> for super::Machine {
     type Result = MessageResult<Request>;
 
     fn handle(&mut self, _: Request, _: &mut Context<Self>) -> Self::Result {
-        if let Some(machine) = &self.state {
-            let state = machine.for_current_state(|s| s.name().to_owned());
-            return MessageResult(Response {
-                state,
-                version: crate::version().to_string(),
-                config: self.shared_state.settings.0.clone(),
-                firmware: self.shared_state.firmware.0.clone(),
-                runtime_settings: self.shared_state.runtime_settings.clone(),
-            });
-        }
-
-        unreachable!("Failed to take StateMachine's ownership");
+        let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
+        let state = machine.for_current_state(|s| s.name().to_owned());
+        MessageResult(Response {
+            state,
+            version: crate::version().to_string(),
+            config: self.shared_state.settings.0.clone(),
+            firmware: self.shared_state.firmware.0.clone(),
+            runtime_settings: self.shared_state.runtime_settings.clone(),
+        })
     }
 }

--- a/updatehub/src/states/actor/info.rs
+++ b/updatehub/src/states/actor/info.rs
@@ -15,7 +15,7 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, _: Request, _: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let state = machine.for_any_state(|s| s.name().to_owned());
+            let state = machine.for_current_state(|s| s.name().to_owned());
             return MessageResult(Response {
                 state,
                 version: crate::version().to_string(),

--- a/updatehub/src/states/actor/local_install.rs
+++ b/updatehub/src/states/actor/local_install.rs
@@ -20,7 +20,7 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let res = machine.for_any_state(|s| s.handle_local_install());
+            let res = machine.for_current_state(|s| s.handle_local_install());
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {

--- a/updatehub/src/states/actor/local_install.rs
+++ b/updatehub/src/states/actor/local_install.rs
@@ -19,20 +19,17 @@ impl Handler<Request> for super::Machine {
     type Result = MessageResult<Request>;
 
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
-        if let Some(machine) = &self.state {
-            let state = machine.for_current_state(|s| s.name().to_owned());
-            if machine.for_current_state(|s| s.can_run_local_install()) {
-                crate::logger::start_memory_logging();
-                self.stepper.restart(ctx.address());
-                self.state.replace(StateMachine::PrepareLocalInstall(State(PrepareLocalInstall {
-                    update_file: req.0,
-                })));
-                return MessageResult(Response::RequestAccepted(state));
-            }
-
-            return MessageResult(Response::InvalidState(state));
+        let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
+        let state = machine.for_current_state(|s| s.name().to_owned());
+        if machine.for_current_state(|s| s.can_run_local_install()) {
+            crate::logger::start_memory_logging();
+            self.stepper.restart(ctx.address());
+            self.state.replace(StateMachine::PrepareLocalInstall(State(PrepareLocalInstall {
+                update_file: req.0,
+            })));
+            return MessageResult(Response::RequestAccepted(state));
         }
 
-        unreachable!("Failed to take StateMachine's ownership");
+        MessageResult(Response::InvalidState(state))
     }
 }

--- a/updatehub/src/states/actor/local_install.rs
+++ b/updatehub/src/states/actor/local_install.rs
@@ -20,18 +20,17 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let res = machine.for_current_state(|s| s.handle_local_install());
-            return match res {
-                Response::InvalidState(_) => MessageResult(res),
-                Response::RequestAccepted(_) => {
-                    crate::logger::start_memory_logging();
-                    self.stepper.restart(ctx.address());
-                    self.state.replace(StateMachine::PrepareLocalInstall(State(
-                        PrepareLocalInstall { update_file: req.0 },
-                    )));
-                    MessageResult(res)
-                }
-            };
+            let state = machine.for_current_state(|s| s.name().to_owned());
+            if machine.for_current_state(|s| s.can_run_local_install()) {
+                crate::logger::start_memory_logging();
+                self.stepper.restart(ctx.address());
+                self.state.replace(StateMachine::PrepareLocalInstall(State(PrepareLocalInstall {
+                    update_file: req.0,
+                })));
+                return MessageResult(Response::RequestAccepted(state));
+            }
+
+            return MessageResult(Response::InvalidState(state));
         }
 
         unreachable!("Failed to take StateMachine's ownership");

--- a/updatehub/src/states/actor/mod.rs
+++ b/updatehub/src/states/actor/mod.rs
@@ -14,18 +14,29 @@ pub(crate) mod remote_install;
 pub(crate) mod stepper;
 
 use super::{
-    DirectDownload, EntryPoint, Metadata, PrepareLocalInstall, Probe, RuntimeSettings, Settings,
-    State, StateMachine,
+    DirectDownload, EntryPoint, Metadata, PrepareLocalInstall, RuntimeSettings, Settings, State,
+    StateMachine, Validation,
 };
 use actix::{
     fut::WrapFuture, Actor, Addr, Arbiter, AsyncContext, AtomicResponse, Context, Handler, Message,
 };
 use slog_scope::info;
+use thiserror::Error;
 
 pub(crate) struct Machine {
     state: Option<StateMachine>,
     shared_state: SharedState,
     stepper: stepper::Controller,
+}
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub(crate) enum Error {
+    #[error("Client Error: {0}")]
+    Client(#[from] crate::client::Error),
+    #[error("Runtime Settings Error: {0}")]
+    RuntimeSettings(#[from] crate::runtime_settings::Error),
 }
 
 #[derive(Debug, PartialEq)]

--- a/updatehub/src/states/actor/probe.rs
+++ b/updatehub/src/states/actor/probe.rs
@@ -18,21 +18,18 @@ impl Handler<Request> for super::Machine {
     type Result = MessageResult<Request>;
 
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
-        if let Some(machine) = &self.state {
-            let state = machine.for_current_state(|s| s.name().to_owned());
-            if machine.for_current_state(|s| s.can_run_trigger_probe()) {
-                self.shared_state.runtime_settings.reset_transient_settings();
-                if let Some(server_address) = req.0 {
-                    self.shared_state.runtime_settings.set_custom_server_address(&server_address);
-                }
-                self.stepper.restart(ctx.address());
-                self.state.replace(StateMachine::Probe(State(Probe {})));
-                return MessageResult(Response::RequestAccepted(state));
+        let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
+        let state = machine.for_current_state(|s| s.name().to_owned());
+        if machine.for_current_state(|s| s.can_run_trigger_probe()) {
+            self.shared_state.runtime_settings.reset_transient_settings();
+            if let Some(server_address) = req.0 {
+                self.shared_state.runtime_settings.set_custom_server_address(&server_address);
             }
-
-            return MessageResult(Response::InvalidState(state));
+            self.stepper.restart(ctx.address());
+            self.state.replace(StateMachine::Probe(State(Probe {})));
+            return MessageResult(Response::RequestAccepted(state));
         }
 
-        unreachable!("Failed to take StateMachine's ownership");
+        MessageResult(Response::InvalidState(state))
     }
 }

--- a/updatehub/src/states/actor/probe.rs
+++ b/updatehub/src/states/actor/probe.rs
@@ -19,7 +19,7 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let res = machine.for_any_state(|s| s.handle_trigger_probe());
+            let res = machine.for_current_state(|s| s.handle_trigger_probe());
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {

--- a/updatehub/src/states/actor/remote_install.rs
+++ b/updatehub/src/states/actor/remote_install.rs
@@ -19,7 +19,7 @@ impl Handler<Request> for super::Machine {
 
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
         if let Some(machine) = &self.state {
-            let res = machine.for_any_state(|s| s.handle_remote_install());
+            let res = machine.for_current_state(|s| s.handle_remote_install());
             return match res {
                 Response::InvalidState(_) => MessageResult(res),
                 Response::RequestAccepted(_) => {

--- a/updatehub/src/states/actor/test.rs
+++ b/updatehub/src/states/actor/test.rs
@@ -129,9 +129,10 @@ async fn step_sequence() {
 #[actix_rt::test]
 async fn download_abort() {
     let (addr, mock, ..) = setup_actor(Setup::HasUpdate, Probe::Enabled);
-    addr.send(Step).await.unwrap();
-    addr.send(Step).await.unwrap();
-    addr.send(Step).await.unwrap();
+    addr.send(Step).await.unwrap(); // Idle -> Poll
+    addr.send(Step).await.unwrap(); // Poll -> Probe
+    addr.send(Step).await.unwrap(); // Probe -> Validation
+    addr.send(Step).await.unwrap(); // Validation -> PrepareDownload
     let res = addr.send(info::Request).await.unwrap();
     assert_eq!(res.state, "prepare_download");
 

--- a/updatehub/src/states/actor/test.rs
+++ b/updatehub/src/states/actor/test.rs
@@ -145,14 +145,16 @@ async fn download_abort() {
 
 #[actix_rt::test]
 async fn trigger_probe() {
-    let (addr, ..) = setup_actor(Setup::NoUpdate, Probe::Disabled);
+    let (addr, mock, ..) = setup_actor(Setup::NoUpdate, Probe::Disabled);
     addr.send(Step).await.unwrap();
     let res = addr.send(info::Request).await.unwrap();
     assert_eq!(res.state, "park");
 
-    addr.send(probe::Request(None)).await.unwrap();
+    addr.send(probe::Request(None)).await.unwrap().unwrap();
     let res = addr.send(info::Request).await.unwrap();
-    assert_eq!(res.state, "probe");
+    assert_eq!(res.state, "entry_point");
+
+    mock.assert();
 }
 
 #[actix_rt::test]

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    actor::{self, download_abort, SharedState},
+    actor::{self, SharedState},
     EntryPoint, Install, ProgressReporter, Result, State, StateChangeImpl, StateMachine,
     TransitionCallback, TransitionError,
 };
@@ -64,8 +64,8 @@ impl StateChangeImpl for State<Download> {
         "download"
     }
 
-    fn handle_download_abort(&self) -> download_abort::Response {
-        download_abort::Response::RequestAccepted
+    fn can_run_download_abort(&self) -> bool {
+        true
     }
 
     async fn handle(

--- a/updatehub/src/states/entry_point.rs
+++ b/updatehub/src/states/entry_point.rs
@@ -22,16 +22,16 @@ impl StateChangeImpl for State<EntryPoint> {
         "entry_point"
     }
 
-    fn handle_trigger_probe(&self) -> actor::probe::Response {
-        actor::probe::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_trigger_probe(&self) -> bool {
+        true
     }
 
-    fn handle_local_install(&self) -> actor::local_install::Response {
-        actor::local_install::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_local_install(&self) -> bool {
+        true
     }
 
-    fn handle_remote_install(&self) -> actor::remote_install::Response {
-        actor::remote_install::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_remote_install(&self) -> bool {
+        true
     }
 
     async fn handle(

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -16,6 +16,7 @@ mod prepare_download;
 mod prepare_local_install;
 mod probe;
 mod reboot;
+mod validation;
 
 #[cfg(test)]
 mod tests;
@@ -24,6 +25,7 @@ use self::{
     direct_download::DirectDownload, download::Download, entry_point::EntryPoint, error::Error,
     install::Install, park::Park, poll::Poll, prepare_download::PrepareDownload,
     prepare_local_install::PrepareLocalInstall, probe::Probe, reboot::Reboot,
+    validation::Validation,
 };
 use crate::{
     firmware::{self, Metadata, Transition},
@@ -127,6 +129,7 @@ enum StateMachine {
     EntryPoint(State<EntryPoint>),
     Poll(State<Poll>),
     Probe(State<Probe>),
+    Validation(State<Validation>),
     PrepareDownload(State<PrepareDownload>),
     DirectDownload(State<DirectDownload>),
     PrepareLocalInstall(State<PrepareLocalInstall>),
@@ -244,6 +247,7 @@ impl StateMachine {
             StateMachine::EntryPoint(s) => s.handle(shared_state).await,
             StateMachine::Poll(s) => s.handle(shared_state).await,
             StateMachine::Probe(s) => s.handle(shared_state).await,
+            StateMachine::Validation(s) => s.handle(shared_state).await,
             StateMachine::PrepareDownload(s) => s.handle(shared_state).await,
             StateMachine::DirectDownload(s) => s.handle(shared_state).await,
             StateMachine::PrepareLocalInstall(s) => s.handle(shared_state).await,
@@ -269,6 +273,7 @@ impl StateMachine {
             StateMachine::EntryPoint(s) => f(s),
             StateMachine::Poll(s) => f(s),
             StateMachine::Probe(s) => f(s),
+            StateMachine::Validation(s) => f(s),
             StateMachine::PrepareDownload(s) => f(s),
             StateMachine::DirectDownload(s) => f(s),
             StateMachine::PrepareLocalInstall(s) => f(s),

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -93,20 +93,20 @@ trait StateChangeImpl {
 
     fn name(&self) -> &'static str;
 
-    fn handle_download_abort(&self) -> actor::download_abort::Response {
-        actor::download_abort::Response::InvalidState
+    fn can_run_download_abort(&self) -> bool {
+        false
     }
 
-    fn handle_trigger_probe(&self) -> actor::probe::Response {
-        actor::probe::Response::InvalidState(self.name().to_owned())
+    fn can_run_trigger_probe(&self) -> bool {
+        false
     }
 
-    fn handle_local_install(&self) -> actor::local_install::Response {
-        actor::local_install::Response::InvalidState(self.name().to_owned())
+    fn can_run_local_install(&self) -> bool {
+        false
     }
 
-    fn handle_remote_install(&self) -> actor::remote_install::Response {
-        actor::remote_install::Response::InvalidState(self.name().to_owned())
+    fn can_run_remote_install(&self) -> bool {
+        false
     }
 }
 

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -263,7 +263,7 @@ impl StateMachine {
         }
     }
 
-    fn for_any_state<F, A>(&self, f: F) -> A
+    fn for_current_state<F, A>(&self, f: F) -> A
     where
         F: Fn(&dyn StateChangeImpl) -> A,
     {

--- a/updatehub/src/states/park.rs
+++ b/updatehub/src/states/park.rs
@@ -20,16 +20,16 @@ impl StateChangeImpl for State<Park> {
         "park"
     }
 
-    fn handle_trigger_probe(&self) -> actor::probe::Response {
-        actor::probe::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_trigger_probe(&self) -> bool {
+        true
     }
 
-    fn handle_local_install(&self) -> actor::local_install::Response {
-        actor::local_install::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_local_install(&self) -> bool {
+        true
     }
 
-    fn handle_remote_install(&self) -> actor::remote_install::Response {
-        actor::remote_install::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_remote_install(&self) -> bool {
+        true
     }
 
     async fn handle(self, _: &mut SharedState) -> Result<(StateMachine, actor::StepTransition)> {

--- a/updatehub/src/states/prepare_download.rs
+++ b/updatehub/src/states/prepare_download.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    actor::{self, download_abort, SharedState},
+    actor::{self, SharedState},
     Download, Result, State, StateChangeImpl, StateMachine,
 };
 use crate::{
@@ -26,8 +26,8 @@ impl StateChangeImpl for State<PrepareDownload> {
         "prepare_download"
     }
 
-    fn handle_download_abort(&self) -> download_abort::Response {
-        download_abort::Response::RequestAccepted
+    fn can_run_download_abort(&self) -> bool {
+        true
     }
 
     async fn handle(

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -4,7 +4,7 @@
 
 use super::{
     actor::{self, SharedState},
-    EntryPoint, Poll, PrepareDownload, Result, State, StateChangeImpl, StateMachine,
+    EntryPoint, Poll, Result, State, StateChangeImpl, StateMachine, Validation,
 };
 use crate::client::{self, Api, ProbeResponse};
 use chrono::Utc;
@@ -70,30 +70,15 @@ impl StateChangeImpl for State<Probe> {
                 ))
             }
 
-            ProbeResponse::Update(u, sign) => {
+            ProbeResponse::Update(package, sign) => {
                 // Store timestamp of last polling
                 shared_state.runtime_settings.set_last_polling(Utc::now())?;
 
-                if let (Some(sign), Some(key)) = (sign, shared_state.firmware.pub_key.as_ref()) {
-                    debug!("Validating signature");
-                    sign.validate(key, &u)?;
-                }
-                // Ensure the package is compatible
-                u.compatible_with(&shared_state.firmware)?;
-
-                if Some(u.package_uid()) == shared_state.runtime_settings.applied_package_uid() {
-                    info!(
-                        "Not applying the update package. Same package has already been installed."
-                    );
-                    debug!("Moving to EntryPoint as this update package is already installed.");
-                    Ok((StateMachine::EntryPoint(self.into()), actor::StepTransition::Immediate))
-                } else {
-                    debug!("Moving to PrepareDownload state to process the update package.");
-                    Ok((
-                        StateMachine::PrepareDownload(State(PrepareDownload { update_package: u })),
-                        actor::StepTransition::Immediate,
-                    ))
-                }
+                info!("Update received.");
+                Ok((
+                    StateMachine::Validation(State(Validation { package, sign })),
+                    actor::StepTransition::Immediate,
+                ))
             }
         }
     }
@@ -177,29 +162,7 @@ mod tests {
 
         mock.assert();
 
-        assert_state!(machine, PrepareDownload);
-    }
-
-    #[actix_rt::test]
-    async fn invalid_hardware() {
-        let tmpfile = NamedTempFile::new().unwrap();
-        let tmpfile = tmpfile.path();
-        fs::remove_file(&tmpfile).unwrap();
-
-        let mock = create_mock_server(FakeServer::InvalidHardware);
-
-        let settings = Settings::default();
-        let runtime_settings = RuntimeSettings::load(tmpfile).unwrap();
-        let firmware =
-            Metadata::from_path(&create_fake_metadata(FakeDevice::InvalidHardware)).unwrap();
-        let mut shared_state = SharedState { settings, runtime_settings, firmware };
-
-        let machine =
-            StateMachine::Probe(State(Probe {})).move_to_next_state(&mut shared_state).await;
-
-        mock.assert();
-
-        assert!(machine.is_err(), "Did not catch an incompatible hardware");
+        assert_state!(machine, Validation);
     }
 
     #[actix_rt::test]
@@ -224,48 +187,6 @@ mod tests {
         mock.assert();
 
         assert_state!(machine, Probe);
-    }
-
-    #[actix_rt::test]
-    async fn skip_same_package_uid() {
-        let tmpfile = NamedTempFile::new().unwrap();
-        let tmpfile = tmpfile.path();
-        fs::remove_file(&tmpfile).unwrap();
-
-        let mock = create_mock_server(FakeServer::HasUpdate).expect(2);
-
-        let mut runtime_settings = RuntimeSettings::load(tmpfile).unwrap();
-
-        // We first get the package_uid that will be returned so we can
-        // use it for the upcoming test.
-        //
-        // This has been done so we don't need to manually update it every
-        // time we change the package payload.
-        let probe = Api::new(&Settings::default().network.server_address)
-            .probe(
-                &RuntimeSettings::default(),
-                &Metadata::from_path(&create_fake_metadata(FakeDevice::HasUpdate)).unwrap(),
-            )
-            .await
-            .unwrap();
-
-        if let ProbeResponse::Update(u, _) = probe {
-            runtime_settings.set_applied_package_uid(&u.package_uid()).unwrap();
-        }
-
-        let settings = Settings::default();
-        let firmware = Metadata::from_path(&create_fake_metadata(FakeDevice::HasUpdate)).unwrap();
-        let mut shared_state = SharedState { settings, runtime_settings, firmware };
-
-        let machine = StateMachine::Probe(State(Probe {}))
-            .move_to_next_state(&mut shared_state)
-            .await
-            .unwrap()
-            .0;
-
-        mock.assert();
-
-        assert_state!(machine, EntryPoint);
     }
 
     #[actix_rt::test]

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -24,8 +24,8 @@ impl StateChangeImpl for State<Probe> {
         "probe"
     }
 
-    fn handle_trigger_probe(&self) -> actor::probe::Response {
-        actor::probe::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_trigger_probe(&self) -> bool {
+        true
     }
 
     async fn handle(

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -71,14 +71,15 @@ impl StateChangeImpl for State<Probe> {
             }
 
             ProbeResponse::Update(u, sign) => {
+                // Store timestamp of last polling
+                shared_state.runtime_settings.set_last_polling(Utc::now())?;
+
                 if let (Some(sign), Some(key)) = (sign, shared_state.firmware.pub_key.as_ref()) {
                     debug!("Validating signature");
                     sign.validate(key, &u)?;
                 }
                 // Ensure the package is compatible
                 u.compatible_with(&shared_state.firmware)?;
-                // Store timestamp of last polling
-                shared_state.runtime_settings.set_last_polling(Utc::now())?;
 
                 if Some(u.package_uid()) == shared_state.runtime_settings.applied_package_uid() {
                     info!(

--- a/updatehub/src/states/validation.rs
+++ b/updatehub/src/states/validation.rs
@@ -24,8 +24,8 @@ impl StateChangeImpl for State<Validation> {
         "validation"
     }
 
-    fn handle_trigger_probe(&self) -> actor::probe::Response {
-        actor::probe::Response::RequestAccepted(self.name().to_owned())
+    fn can_run_trigger_probe(&self) -> bool {
+        true
     }
 
     async fn handle(

--- a/updatehub/src/states/validation.rs
+++ b/updatehub/src/states/validation.rs
@@ -1,0 +1,148 @@
+// Copyright (C) 2020 O.S. Systems Sofware LTDA
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    actor::{self, SharedState},
+    EntryPoint, PrepareDownload, Result, State, StateChangeImpl, StateMachine,
+};
+use crate::update_package::{Signature, UpdatePackage};
+use slog_scope::{debug, info};
+
+#[derive(Debug, PartialEq)]
+pub(super) struct Validation {
+    pub(super) package: UpdatePackage,
+    pub(super) sign: Option<Signature>,
+}
+
+create_state_step!(Validation => EntryPoint);
+
+/// Implements the state change for State<Validation>.
+#[async_trait::async_trait]
+impl StateChangeImpl for State<Validation> {
+    fn name(&self) -> &'static str {
+        "validation"
+    }
+
+    fn handle_trigger_probe(&self) -> actor::probe::Response {
+        actor::probe::Response::RequestAccepted(self.name().to_owned())
+    }
+
+    async fn handle(
+        self,
+        shared_state: &mut SharedState,
+    ) -> Result<(StateMachine, actor::StepTransition)> {
+        if let (Some(sign), Some(key)) =
+            (self.0.sign.as_ref(), shared_state.firmware.pub_key.as_ref())
+        {
+            debug!("Validating signature");
+            sign.validate(key, &self.0.package)?;
+        }
+
+        // Ensure the package is compatible
+        self.0.package.compatible_with(&shared_state.firmware)?;
+
+        if shared_state
+            .runtime_settings
+            .applied_package_uid()
+            .map(|u| *u == self.0.package.package_uid())
+            .unwrap_or_default()
+        {
+            info!("Not downloading update package. Same package has already been installed.");
+            debug!("Moving to EntryPoint as this update package is already installed.");
+            Ok((StateMachine::EntryPoint(self.into()), actor::StepTransition::Immediate))
+        } else {
+            debug!("Moving to PrepareDownload state to process the update package.");
+            Ok((
+                StateMachine::PrepareDownload(State(PrepareDownload {
+                    update_package: self.0.package,
+                })),
+                actor::StepTransition::Immediate,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        firmware::{
+            tests::{create_fake_metadata, FakeDevice},
+            Metadata,
+        },
+        runtime_settings::RuntimeSettings,
+        settings::Settings,
+        states::TransitionError,
+        update_package::tests::get_update_package,
+    };
+    use tempfile::NamedTempFile;
+
+    #[actix_rt::test]
+    async fn normal_transition() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        let tmpfile = tmpfile.path();
+        std::fs::remove_file(&tmpfile).unwrap();
+
+        let settings = Settings::default();
+        let runtime_settings = RuntimeSettings::load(tmpfile).unwrap();
+        let firmware = Metadata::from_path(&create_fake_metadata(FakeDevice::HasUpdate)).unwrap();
+        let mut shared_state = SharedState { settings, runtime_settings, firmware };
+        let package = get_update_package();
+        let sign = None;
+
+        let machine = StateMachine::Validation(State(Validation { package, sign }))
+            .move_to_next_state(&mut shared_state)
+            .await
+            .unwrap()
+            .0;
+        assert_state!(machine, PrepareDownload);
+    }
+
+    #[actix_rt::test]
+    async fn invalid_hardware() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        let tmpfile = tmpfile.path();
+        std::fs::remove_file(&tmpfile).unwrap();
+
+        let settings = Settings::default();
+        let runtime_settings = RuntimeSettings::load(tmpfile).unwrap();
+        let firmware =
+            Metadata::from_path(&create_fake_metadata(FakeDevice::InvalidHardware)).unwrap();
+        let mut shared_state = SharedState { settings, runtime_settings, firmware };
+        let package = get_update_package();
+        let sign = None;
+
+        let machine = StateMachine::Validation(State(Validation { package, sign }))
+            .move_to_next_state(&mut shared_state)
+            .await;
+
+        match machine {
+            Err(TransitionError::UpdatePackage(_)) => {}
+            res => panic!("Unexpected result from transition: {:?}", res),
+        }
+    }
+
+    #[actix_rt::test]
+    async fn skip_same_package_uid() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        let tmpfile = tmpfile.path();
+        std::fs::remove_file(&tmpfile).unwrap();
+
+        let runtime_settings = RuntimeSettings::load(tmpfile).unwrap();
+        let settings = Settings::default();
+        let firmware = Metadata::from_path(&create_fake_metadata(FakeDevice::HasUpdate)).unwrap();
+        let mut shared_state = SharedState { settings, runtime_settings, firmware };
+
+        let package = get_update_package();
+        let sign = None;
+        shared_state.runtime_settings.set_applied_package_uid(&package.package_uid()).unwrap();
+
+        let machine = StateMachine::Validation(State(Validation { package, sign }))
+            .move_to_next_state(&mut shared_state)
+            .await
+            .unwrap()
+            .0;
+        assert_state!(machine, EntryPoint);
+    }
+}

--- a/updatehub/src/update_package/mod.rs
+++ b/updatehub/src/update_package/mod.rs
@@ -35,7 +35,7 @@ pub(crate) struct UpdatePackage {
     raw: Vec<u8>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Signature(pub(crate) Vec<u8>);
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This also rework some of the internal code structure.

* general: Make last_poll always present
* general: Rework extra_interval handling logic
* updatehub: Update poll handle logic
* updatehub: Register last polling even if validation fails
* updatehub: Move update package validation to it's own state
* updatehub: Rename generic state runner to for_current_state
* updatehub: Rework actor current message handling logic
* updatehub: use expect for Machine's state on message handles
* updatehub: Unexpose http_api internal error
* sdk: Make api::probe::Response try again field optional
* updatehub: Rework trigger probe request

