### PR TITLE
updatehub: Run rollback callback on new image

### DIFF
--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -213,15 +213,13 @@ fn handle_startup_callbacks(
                 Transition::Cancel => {
                     warn!("Validate callback has failed");
                     firmware::installation_set::swap_active()?;
-                    warn!("Swapped active installation set and rebooting");
+                    warn!("Swapped active installation set and running rollback");
+                    firmware::rollback_callback(&settings.firmware.metadata)?;
                     easy_process::run("reboot")?;
                 }
                 Transition::Continue => firmware::installation_set::validate()?,
             }
             return Ok(());
-        } else {
-            warn!("Agent is not running on expected installation set, running rollback callback");
-            firmware::rollback_callback(&settings.firmware.metadata)?;
         }
 
         runtime_settings.reset_installation_settings()?;


### PR DESCRIPTION
The rollback callback is now executed on the new installed image, this allows
the scripts to fix (i.e. rollback) any modifications to the system caused by
the faulty installation of the new image

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>