### PR TITLE
updatehub: Use request types from sdk

### DIFF
--- a/updatehub-sdk/src/api/mod.rs
+++ b/updatehub-sdk/src/api/mod.rs
@@ -22,6 +22,26 @@ pub mod probe {
     }
 }
 
+pub mod local_install {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Deserialize, Clone, Debug, Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Request {
+        pub file: std::path::PathBuf,
+    }
+}
+
+pub mod remote_install {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Deserialize, Clone, Debug, Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Request {
+        pub url: String,
+    }
+}
+
 pub mod state {
     use serde::{Deserialize, Serialize};
 

--- a/updatehub-sdk/src/client/mod.rs
+++ b/updatehub-sdk/src/client/mod.rs
@@ -50,17 +50,10 @@ impl Client {
     }
 
     pub async fn local_install(&self, file: &Path) -> Result<api::state::Response> {
-        use serde::Serialize;
-        #[derive(Clone, Debug, Serialize)]
-        #[serde(deny_unknown_fields)]
-        pub struct Request<'a> {
-            pub file: &'a Path,
-        }
-
         let mut response = self
             .client
             .post(&format!("{}/local_install", self.server_address))
-            .send_json(&Request { file })
+            .send_json(&api::local_install::Request { file: file.to_owned() })
             .await?;
 
         match response.status() {
@@ -73,17 +66,10 @@ impl Client {
     }
 
     pub async fn remote_install(&self, url: &str) -> Result<api::state::Response> {
-        use serde::Serialize;
-        #[derive(Clone, Debug, Serialize)]
-        #[serde(deny_unknown_fields)]
-        pub struct Request<'a> {
-            pub url: &'a str,
-        }
-
         let mut response = self
             .client
             .post(&format!("{}/remote_install", self.server_address))
-            .send_json(&Request { url })
+            .send_json(&api::remote_install::Request { url: url.to_owned() })
             .await?;
 
         match response.status() {

--- a/updatehub/src/http_api.rs
+++ b/updatehub/src/http_api.rs
@@ -47,18 +47,18 @@ impl API {
 
     async fn local_install(
         agent: web::Data<API>,
-        file_path: String,
+        req: web::Json<api::local_install::Request>,
     ) -> Result<actor::local_install::Response> {
-        debug!("Receiving local_install request with {:?}", file_path);
-        Ok(agent.0.send(actor::local_install::Request(std::path::PathBuf::from(file_path))).await?)
+        debug!("Receiving local_install request with {:?}", req);
+        Ok(agent.0.send(actor::local_install::Request(req.into_inner().file)).await?)
     }
 
     async fn remote_install(
         agent: web::Data<API>,
-        url: String,
+        req: web::Json<api::remote_install::Request>,
     ) -> Result<actor::remote_install::Response> {
-        debug!("Receiving remote_install request with {:?}", url);
-        Ok(agent.0.send(actor::remote_install::Request(url)).await?)
+        debug!("Receiving remote_install request with {:?}", req);
+        Ok(agent.0.send(actor::remote_install::Request(req.into_inner().url)).await?)
     }
 
     async fn log() -> HttpResponse {


### PR DESCRIPTION
This fixes the Agent's client SDK not being able to communicate with the updatehub local server due to the API change on #267. 