### PR TITLE
updatehub: Avoid blocking state machine

### DIFF
--- a/updatehub/src/states/actor/stepper.rs
+++ b/updatehub/src/states/actor/stepper.rs
@@ -69,7 +69,7 @@ impl Controller {
                         Ok(super::StepTransition::Immediate) => {}
                         Ok(super::StepTransition::Delayed(t)) => {
                             debug!("Sleeping stepper thread for: {} seconds", t.as_secs());
-                            std::thread::sleep(t);
+                            actix::clock::delay_for(t).await;
                         }
                         Ok(super::StepTransition::Never) => {
                             info!("Stopping step messages");


### PR DESCRIPTION
Download state transition now yields when download is still pending so other
futures in the same event loop can progress. Stepper now uses a non-blocking
wait when delayed transition is requested.

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>