### PR TITLE
Threat a missing signature on pkg as an error and clippy note

### DIFF
--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -195,6 +195,7 @@ mod tests {
         obj.install(&download_dir.path())?;
 
         // Validade File
+        #[allow(clippy::redundant_clone)]
         utils::fs::mount_map(&device, obj.filesystem, &obj.mount_options.clone(), |path| {
             let chunk_size = definitions::ChunkSize::default().0;
             let dest = path.join(&obj.target_path);

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -122,6 +122,7 @@ mod tests {
         obj.install(&PathBuf::from("test/fixtures"))?;
 
         // Validade File
+        #[allow(clippy::redundant_clone)]
         utils::fs::mount_map(&device, obj.filesystem, &obj.mount_options.clone(), |path| {
             let assert_metadata = |p: &Path| -> crate::utils::Result<()> {
                 let metadata = p.metadata()?;

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -45,6 +45,9 @@ pub enum TransitionError {
     #[error("Not all objects are ready for use")]
     ObjectsNotReady,
 
+    #[error("Signature not found")]
+    SignatureNotFound,
+
     #[error("Failed to read from channel: {0}")]
     MpscRecv(mpsc::TryRecvError),
 

--- a/updatehub/src/states/prepare_local_install.rs
+++ b/updatehub/src/states/prepare_local_install.rs
@@ -52,7 +52,9 @@ impl StateChangeImpl for State<PrepareLocalInstall> {
                     debug!("Validating signature");
                     sign.validate(key, &update_package)?;
                 }
-                Err(compress_tools::Error::FileNotFound) => {}
+                Err(compress_tools::Error::FileNotFound) => {
+                    return Err(super::TransitionError::SignatureNotFound);
+                }
                 Err(e) => return Err(e.into()),
             }
         }


### PR DESCRIPTION
When the device has a signature key setup and the package is not signed a "SingatureNotFound" is raised on the installation process for both downloaded packages and local install.