### PR TITLE
updatehub: Rework StateChangeImpl methods for external messages

### DIFF
--- a/updatehub/src/states/actor/download_abort.rs
+++ b/updatehub/src/states/actor/download_abort.rs
@@ -20,7 +20,7 @@ impl Handler<Request> for super::Machine {
     fn handle(&mut self, _: Request, _: &mut Context<Self>) -> Self::Result {
         let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
 
-        if machine.for_current_state(|s| s.can_run_download_abort()) {
+        if machine.for_current_state(|s| s.is_handling_download()) {
             self.state.replace(StateMachine::EntryPoint(State(EntryPoint {})));
             return MessageResult(Response::RequestAccepted);
         }

--- a/updatehub/src/states/actor/local_install.rs
+++ b/updatehub/src/states/actor/local_install.rs
@@ -21,7 +21,7 @@ impl Handler<Request> for super::Machine {
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
         let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
         let state = machine.for_current_state(|s| s.name().to_owned());
-        if machine.for_current_state(|s| s.can_run_local_install()) {
+        if machine.for_current_state(|s| s.is_preemptive_state()) {
             crate::logger::start_memory_logging();
             self.stepper.restart(ctx.address());
             self.state.replace(StateMachine::PrepareLocalInstall(State(PrepareLocalInstall {

--- a/updatehub/src/states/actor/probe.rs
+++ b/updatehub/src/states/actor/probe.rs
@@ -43,7 +43,7 @@ impl super::Machine {
     ) -> super::Result<Response> {
         let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
 
-        if machine.for_current_state(|s| s.can_run_trigger_probe()) {
+        if machine.for_current_state(|s| s.is_preemptive_state()) {
             self.shared_state.runtime_settings.reset_transient_settings();
             if let Some(server_address) = custom_server {
                 self.shared_state.runtime_settings.set_custom_server_address(&server_address);

--- a/updatehub/src/states/actor/remote_install.rs
+++ b/updatehub/src/states/actor/remote_install.rs
@@ -20,7 +20,7 @@ impl Handler<Request> for super::Machine {
     fn handle(&mut self, req: Request, ctx: &mut Context<Self>) -> Self::Result {
         let machine = self.state.as_ref().expect("Failed to take StateMachine's ownership");
         let state = machine.for_current_state(|s| s.name().to_owned());
-        if machine.for_current_state(|s| s.can_run_remote_install()) {
+        if machine.for_current_state(|s| s.is_preemptive_state()) {
             crate::logger::start_memory_logging();
             self.stepper.restart(ctx.address());
             self.state.replace(StateMachine::DirectDownload(State(DirectDownload { url: req.0 })));

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -64,7 +64,7 @@ impl StateChangeImpl for State<Download> {
         "download"
     }
 
-    fn can_run_download_abort(&self) -> bool {
+    fn is_handling_download(&self) -> bool {
         true
     }
 

--- a/updatehub/src/states/entry_point.rs
+++ b/updatehub/src/states/entry_point.rs
@@ -22,15 +22,7 @@ impl StateChangeImpl for State<EntryPoint> {
         "entry_point"
     }
 
-    fn can_run_trigger_probe(&self) -> bool {
-        true
-    }
-
-    fn can_run_local_install(&self) -> bool {
-        true
-    }
-
-    fn can_run_remote_install(&self) -> bool {
+    fn is_preemptive_state(&self) -> bool {
         true
     }
 

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -90,19 +90,16 @@ trait StateChangeImpl {
 
     fn name(&self) -> &'static str;
 
-    fn can_run_download_abort(&self) -> bool {
+    /// All states downloading large files should overwrite this to return true.
+    /// That way, a external request to abort download can be heeded.
+    fn is_handling_download(&self) -> bool {
         false
     }
 
-    fn can_run_trigger_probe(&self) -> bool {
-        false
-    }
-
-    fn can_run_local_install(&self) -> bool {
-        false
-    }
-
-    fn can_run_remote_install(&self) -> bool {
+    /// A preemptive state is a state whose transition can be yield
+    /// to handle a user's request. Any preemptive state should overwrite
+    /// this method to return true.
+    fn is_preemptive_state(&self) -> bool {
         false
     }
 }

--- a/updatehub/src/states/park.rs
+++ b/updatehub/src/states/park.rs
@@ -20,15 +20,7 @@ impl StateChangeImpl for State<Park> {
         "park"
     }
 
-    fn can_run_trigger_probe(&self) -> bool {
-        true
-    }
-
-    fn can_run_local_install(&self) -> bool {
-        true
-    }
-
-    fn can_run_remote_install(&self) -> bool {
+    fn is_preemptive_state(&self) -> bool {
         true
     }
 

--- a/updatehub/src/states/poll.rs
+++ b/updatehub/src/states/poll.rs
@@ -23,6 +23,10 @@ impl StateChangeImpl for State<Poll> {
         "poll"
     }
 
+    fn is_preemptive_state(&self) -> bool {
+        true
+    }
+
     async fn handle(
         self,
         shared_state: &mut SharedState,

--- a/updatehub/src/states/prepare_download.rs
+++ b/updatehub/src/states/prepare_download.rs
@@ -24,7 +24,7 @@ impl StateChangeImpl for State<PrepareDownload> {
         "prepare_download"
     }
 
-    fn can_run_download_abort(&self) -> bool {
+    fn is_handling_download(&self) -> bool {
         true
     }
 

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -24,7 +24,7 @@ impl StateChangeImpl for State<Probe> {
         "probe"
     }
 
-    fn can_run_trigger_probe(&self) -> bool {
+    fn is_preemptive_state(&self) -> bool {
         true
     }
 

--- a/updatehub/src/states/validation.rs
+++ b/updatehub/src/states/validation.rs
@@ -24,7 +24,7 @@ impl StateChangeImpl for State<Validation> {
         "validation"
     }
 
-    fn can_run_trigger_probe(&self) -> bool {
+    fn is_preemptive_state(&self) -> bool {
         true
     }
 


### PR DESCRIPTION
This also silently fixes a bug where local install couldn't be triggered while the agent was waiting for the setup time for probing the server. This happens because the state already supported the `trigger_probe` request. Now that the methods have been unified, the state can handle all three requests as intended.