### PR TITLE
updatehub: Add test-env feature to default features

### DIFF
--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [features]
-default = []
+default = ["test-env"]
 
 # Feature to allow deserialization from v1 Settings
 v1-parsing = ["serde_ini"]


### PR DESCRIPTION
This makes development build easier as it wont be necessary to manually add the
feature in order to run tests

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>