### PR TITLE
updatehub: tests: Use 'matches!' macro to simplify code

### DIFF
--- a/updatehub/src/states/macros.rs
+++ b/updatehub/src/states/macros.rs
@@ -6,7 +6,7 @@
 macro_rules! assert_state {
     ($machine:ident, $state:ident) => {
         assert!(
-            if let State::$state(_) = $machine { true } else { false },
+            matches!($machine, State::$state(_)),
             "Failed to get to {} state.",
             stringify!($state),
         );


### PR DESCRIPTION
This simplify the code avoiding 'if let' construction. This requires
Rust 1.42.0 which is our MSRV.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>