### PR TITLE
CI: Fix cargo bloat not being ignoring for execution

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,7 +79,7 @@ jobs:
           args: --release --all --all-features --no-fail-fast -- --nocapture
 
       - name: Run cargo bloat
-        if: matrix.version == '1.42.0'
+        if: matrix.version == '1.42.0' && 0
         uses: orf/cargo-bloat-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Last CI fix PR (#305) attempt to ignore cargo bloat execution but one of the steps was missed causing linux build to fail for Rust 1.42. This PR should fix that.