### PR TITLE
updatehub: Fix misuse of required size value for uncompressed objects

### DIFF
--- a/updatehub/src/object/macros.rs
+++ b/updatehub/src/object/macros.rs
@@ -76,7 +76,7 @@ macro_rules! impl_compressed_object_info {
             }
 
             fn required_install_size(&self) -> u64 {
-                self.required_uncompressed_size
+                if self.compressed { self.required_uncompressed_size } else { self.size }
             }
         }
     };


### PR DESCRIPTION
Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>