### PR TITLE
updatehub: Fix the dynamic bind socket for tests

### DIFF
--- a/updatehub/src/main.rs
+++ b/updatehub/src/main.rs
@@ -25,6 +25,10 @@ enum EntryPoints {
 struct ClientOptions {
     #[argh(subcommand)]
     commands: ClientCommands,
+
+    /// change the client socket to listen
+    #[argh(option, default = "String::from(\"localhost:8080\")")]
+    listen_socket: String,
 }
 
 #[derive(FromArgs)]
@@ -109,8 +113,8 @@ async fn server_main(cmd: ServerOptions) -> updatehub::Result<()> {
     Ok(())
 }
 
-async fn client_main(cmd: ClientCommands) -> updatehub::Result<()> {
-    let client = sdk::Client::new("localhost:8080");
+async fn client_main(cmd: ClientCommands, socket: String) -> updatehub::Result<()> {
+    let client = sdk::Client::new(&socket);
 
     match cmd {
         ClientCommands::Info(_) => println!("{:#?}", client.info().await?),
@@ -166,7 +170,7 @@ async fn main() {
     let cmd: TopLevel = argh::from_env();
 
     let res = match cmd.entry_point {
-        EntryPoints::Client(client) => client_main(client.commands).await,
+        EntryPoints::Client(client) => client_main(client.commands, client.listen_socket).await,
         EntryPoints::Server(cmd) => server_main(cmd).await,
     };
 

--- a/updatehub/tests/common.rs
+++ b/updatehub/tests/common.rs
@@ -127,8 +127,12 @@ pub fn get_output_server(
         .0
 }
 
-pub fn run_client_probe(server: Server) -> String {
-    let cmd_string = format!("{} client probe", cargo_bin("updatehub").to_string_lossy());
+pub fn run_client_probe(server: Server, listen_socket: &str) -> String {
+    let cmd_string = format!(
+        "{} client --listen-socket {} probe",
+        cargo_bin("updatehub").to_string_lossy(),
+        listen_socket
+    );
     let cmd = match server {
         Server::Custom(server_address) => format!("{} --server {}", cmd_string, server_address),
         Server::Standard => cmd_string,
@@ -137,8 +141,12 @@ pub fn run_client_probe(server: Server) -> String {
     handle.exp_eof().expect("fail to match the EOF for client")
 }
 
-pub fn run_client_log() -> String {
-    let cmd = format!("{} client log", cargo_bin("updatehub").to_string_lossy());
+pub fn run_client_log(listen_socket: &str) -> String {
+    let cmd = format!(
+        "{} client --listen-socket {} log",
+        cargo_bin("updatehub").to_string_lossy(),
+        listen_socket
+    );
     let mut handle = rexpect::spawn(&cmd, None).expect("fail to spawn log command");
     handle.exp_eof().expect("fail to match the EOF for client")
 }

--- a/updatehub/tests/failed_integration_test.rs
+++ b/updatehub/tests/failed_integration_test.rs
@@ -22,9 +22,10 @@ fn failing_invalid_download_dir() {
     let _mocks = create_mock_server(FakeServer::HasUpdate(setup.firmware.data.product_uid.clone()));
     let output_server_1 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
 
-    let output_client = run_client_probe(Server::Standard);
+    let output_client =
+        run_client_probe(Server::Standard, &setup.settings.data.network.listen_socket);
     let output_server_2 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce, output_server_info) = rewrite_log_output(output_server_1);
 
@@ -143,11 +144,14 @@ fn failing_invalid_file_config() {
 #[test]
 fn failing_invalid_server_address() {
     let setup = Settings::default();
-    let (mut session, _setup) = setup.timeout(300).init_server();
+    let (mut session, setup) = setup.timeout(300).init_server();
     let _mocks = create_mock_server(FakeServer::NoUpdate);
     let output_server_1 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
 
-    let output_client = run_client_probe(Server::Custom("http://foo:--".to_string()));
+    let output_client = run_client_probe(
+        Server::Custom("http://foo:--".to_string()),
+        &setup.settings.data.network.listen_socket,
+    );
     let output_server_2 = get_output_server(
         &mut session,
         StopMessage::Custom(
@@ -155,7 +159,7 @@ fn failing_invalid_server_address() {
                 .to_string(),
         ),
     );
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce_1, output_server_info_1) = rewrite_log_output(output_server_1);
     let (output_server_trce_2, ..) = rewrite_log_output(output_server_2);
@@ -197,9 +201,10 @@ fn failing_fail_check_requirements() {
     ));
     let output_server_1 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
 
-    let output_client = run_client_probe(Server::Standard);
+    let output_client =
+        run_client_probe(Server::Standard, &setup.settings.data.network.listen_socket);
     let output_server_2 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce_1, output_server_info_1) = rewrite_log_output(output_server_1);
     let (output_server_trce_2, output_server_info_2) = rewrite_log_output(output_server_2);

--- a/updatehub/tests/successful_integration_test.rs
+++ b/updatehub/tests/successful_integration_test.rs
@@ -13,9 +13,9 @@ pub mod common;
 fn correct_config_no_update_no_polling() {
     let setup = Settings::default();
 
-    let (mut session, _setup) = setup.timeout(300).init_server();
+    let (mut session, setup) = setup.timeout(300).init_server();
     let output_server = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce, output_server_info) = rewrite_log_output(output_server);
 
@@ -49,9 +49,9 @@ fn correct_config_no_update_polling() {
     let setup = Settings::default();
     let mocks = create_mock_server(FakeServer::NoUpdate);
 
-    let (mut session, _setup) = setup.timeout(300).polling().init_server();
+    let (mut session, setup) = setup.timeout(300).polling().init_server();
     let output_server = get_output_server(&mut session, StopMessage::Polling(Polling::Enable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce, output_server_info) = rewrite_log_output(output_server);
 
@@ -106,14 +106,15 @@ fn correct_config_no_update_polling_with_probe_api() {
     let setup = Settings::default();
     let mocks = create_mock_server(FakeServer::NoUpdate);
 
-    let (mut session, _setup) = setup.timeout(300).polling().init_server();
+    let (mut session, setup) = setup.timeout(300).polling().init_server();
     let output_server_1 = get_output_server(&mut session, StopMessage::Polling(Polling::Enable));
 
     mocks.iter().for_each(|mock| mock.assert());
 
-    let output_client = run_client_probe(Server::Standard);
+    let output_client =
+        run_client_probe(Server::Standard, &setup.settings.data.network.listen_socket);
     let output_server_2 = get_output_server(&mut session, StopMessage::Polling(Polling::Enable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let mut iter = output_server_2.lines();
     iter.next();
@@ -179,12 +180,13 @@ fn correct_config_no_update_no_polling_with_probe_api() {
     let setup = Settings::default();
     let mocks = create_mock_server(FakeServer::NoUpdate);
 
-    let (mut session, _setup) = setup.timeout(300).init_server();
+    let (mut session, setup) = setup.timeout(300).init_server();
     let output_server_1 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
 
-    let output_client = run_client_probe(Server::Standard);
+    let output_client =
+        run_client_probe(Server::Standard, &setup.settings.data.network.listen_socket);
     let output_server_2 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce, output_server_info) = rewrite_log_output(output_server_1);
 
@@ -240,9 +242,10 @@ fn correct_config_update_no_polling_with_probe_api() {
     let mocks = create_mock_server(FakeServer::HasUpdate(setup.firmware.data.product_uid.clone()));
     let output_server_1 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
 
-    let output_client = run_client_probe(Server::Standard);
+    let output_client =
+        run_client_probe(Server::Standard, &setup.settings.data.network.listen_socket);
     let output_server_2 = get_output_server(&mut session, StopMessage::Polling(Polling::Disable));
-    let output_log = run_client_log();
+    let output_log = run_client_log(&setup.settings.data.network.listen_socket);
 
     let (output_server_trce_1, output_server_info_1) = rewrite_log_output(output_server_1);
     let (output_server_trce_2, output_server_info_2) = rewrite_log_output(output_server_2);


### PR DESCRIPTION
This fix the problem when the socket for server change instead
of the default.

Signed-off-by: asakiz <asakizin@gmail.com>