### PR TITLE
cloud-sdk: Use `usize` for number of `probe` retries

### DIFF
--- a/updatehub-cloud-sdk/src/client.rs
+++ b/updatehub-cloud-sdk/src/client.rs
@@ -91,7 +91,7 @@ impl<'a> Client<'a> {
 
     pub async fn probe(
         &self,
-        num_retries: u64,
+        num_retries: usize,
         firmware: api::FirmwareMetadata<'_>,
     ) -> Result<api::ProbeResponse> {
         validate_url(self.server)?;

--- a/updatehub/src/cloud_mock.rs
+++ b/updatehub/src/cloud_mock.rs
@@ -39,7 +39,7 @@ impl<'a> Client<'a> {
 
     pub(crate) async fn probe(
         &self,
-        _num_retries: u64,
+        _num_retries: usize,
         _firmware: api::FirmwareMetadata<'_>,
     ) -> Result<api::ProbeResponse> {
         RESPONSE_CONFIG.with(|conf| match std::ops::Deref::deref(&conf.borrow()) {

--- a/updatehub/src/states/machine/mod.rs
+++ b/updatehub/src/states/machine/mod.rs
@@ -118,7 +118,7 @@ pub(super) trait CommunicationState: StateChangeImpl {
         }
 
         match crate::CloudClient::new(&context.server_address())
-            .probe(context.runtime_settings.retries() as u64, context.firmware.as_cloud_metadata())
+            .probe(context.runtime_settings.retries(), context.firmware.as_cloud_metadata())
             .await?
         {
             ProbeResponse::ExtraPoll(s) => {

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -28,7 +28,7 @@ impl StateChangeImpl for Probe {
         let server_address = context.server_address();
 
         let probe = match crate::CloudClient::new(&server_address)
-            .probe(context.runtime_settings.retries() as u64, context.firmware.as_cloud_metadata())
+            .probe(context.runtime_settings.retries(), context.firmware.as_cloud_metadata())
             .await
         {
             Err(cloud::Error::Http(e))


### PR DESCRIPTION
We can avoid the use of casting (for u64), which can in fact fail, using `usize`
for the number of probe retries. The `usize` use here seems a good fit
as it matches the word size of the current in-use CPU architecture.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>