### PR TITLE
updatehub: states: Drop `error_callback` support

### DIFF
--- a/updatehub-cloud-sdk/src/client.rs
+++ b/updatehub-cloud-sdk/src/client.rs
@@ -25,7 +25,7 @@ impl Middleware for API {
         client: surf::Client,
         next: middleware::Next<'_>,
     ) -> surf::Result<Response> {
-        req.insert_header(headers::USER_AGENT, "updatehub/next");
+        req.insert_header(headers::USER_AGENT, "updatehub/2.0 Linux");
         req.insert_header(headers::CONTENT_TYPE, "application/json");
         req.insert_header("api-content-type", "application/vnd.updatehub-v1+json");
         Ok(next.run(req, client).await?)

--- a/updatehub/src/firmware/mod.rs
+++ b/updatehub/src/firmware/mod.rs
@@ -23,7 +23,6 @@ const DEVICE_ATTRIBUTES_DIR: &str = "device-attributes.d";
 const STATE_CHANGE_CALLBACK: &str = "state-change-callback";
 const VALIDATE_CALLBACK: &str = "validate-callback";
 const ROLLBACK_CALLBACK: &str = "rollback-callback";
-const ERROR_CALLBACK: &str = "error-callback";
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -146,10 +145,6 @@ pub(crate) fn validate_callback(path: &Path) -> Result<Transition> {
 
 pub(crate) fn rollback_callback(path: &Path) -> Result<()> {
     run_callback("rollback callback", &path.join(ROLLBACK_CALLBACK))
-}
-
-pub(crate) fn error_callback(path: &Path) -> Result<()> {
-    run_callback("error callback", &path.join(ERROR_CALLBACK))
 }
 
 fn run_callback(name: &str, path: &Path) -> Result<()> {

--- a/updatehub/src/states/error.rs
+++ b/updatehub/src/states/error.rs
@@ -7,7 +7,6 @@ use super::{
     CallbackReporter, EntryPoint, Result, State, StateChangeImpl, TransitionError,
 };
 
-use crate::firmware;
 use slog_scope::{error, info};
 
 #[derive(Debug)]
@@ -23,13 +22,8 @@ impl StateChangeImpl for Error {
         "error"
     }
 
-    async fn handle(self, st: &mut Context) -> Result<(State, machine::StepTransition)> {
+    async fn handle(self, _: &mut Context) -> Result<(State, machine::StepTransition)> {
         error!("error state reached: {}", self.error);
-
-        if let Err(err) = firmware::error_callback(&st.settings.firmware.metadata) {
-            error!("failed to run error callback script: {}", err);
-        }
-
         info!("returning to machine's entry point");
         Ok((State::EntryPoint(EntryPoint {}), machine::StepTransition::Immediate))
     }


### PR DESCRIPTION
We have a very robust logging system now and any error is also emitted
to the normal `state_change_callback`. This avoids two ways of handling
same information and drop some complexity for users.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>