### PR TITLE
Add support to parse "v1" runtime settings

### DIFF
--- a/updatehub/src/firmware/tests.rs
+++ b/updatehub/src/firmware/tests.rs
@@ -47,6 +47,10 @@ pub(crate) fn state_change_hook(path: &Path) -> PathBuf {
     path.join(STATE_CHANGE_CALLBACK)
 }
 
+pub(crate) fn validate_hook(path: &Path) -> PathBuf {
+    path.join(VALIDATE_CALLBACK)
+}
+
 pub(crate) fn device_identity_dir(path: &Path) -> PathBuf {
     path.join(DEVICE_IDENTITY_DIR).join("identity")
 }

--- a/updatehub/src/states/machine/mod.rs
+++ b/updatehub/src/states/machine/mod.rs
@@ -62,7 +62,7 @@ pub(super) trait CommunicationState: StateChangeImpl {
                         version: crate::version().to_string(),
                         config: context.settings.0.clone(),
                         firmware: context.firmware.0.clone(),
-                        runtime_settings: context.runtime_settings.0.clone(),
+                        runtime_settings: context.runtime_settings.inner.clone(),
                     }),
                     None,
                 ))

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -207,6 +207,14 @@ fn handle_startup_callbacks(
                     warn!("swapped active installation set and running rollback");
                     firmware::rollback_callback(&settings.firmware.metadata)?;
                     runtime_settings.reset_installation_settings()?;
+
+                    // In case we are booting from an UpdateHub v1 update and
+                    // the validation has failed, we need to restore the
+                    // original content of the file to not break the rollback
+                    // procedure when rebooting.
+                    #[cfg(feature = "v1-parsing")]
+                    runtime_settings.restore_v1_content()?;
+
                     easy_process::run("reboot")?;
                 }
                 Transition::Continue => firmware::installation_set::validate()?,

--- a/updatehub/tests/common.rs
+++ b/updatehub/tests/common.rs
@@ -38,6 +38,8 @@ pub struct Settings {
     timeout: Option<u64>,
     install_modes: Option<Vec<&'static str>>,
     state_change_callback: Option<&'static str>,
+    validate_callback: Option<&'static str>,
+    booting_from_update: bool,
 }
 
 impl Default for Settings {
@@ -54,6 +56,8 @@ impl Default for Settings {
             timeout: None,
             install_modes: None,
             state_change_callback: None,
+            validate_callback: None,
+            booting_from_update: false,
         }
     }
 }
@@ -64,8 +68,15 @@ impl Settings {
             .listen_socket(self.listen_socket)
             .server_address(self.server_address)
             .add_echo_binary("reboot");
+
+        if self.booting_from_update {
+            setup = setup.booting_from_update();
+        }
         if let Some(s) = self.state_change_callback {
             setup = setup.state_change_callback(s.to_owned());
+        }
+        if let Some(s) = self.validate_callback {
+            setup = setup.validate_callback(s.to_owned());
         }
         if let Some(l) = self.install_modes {
             setup = setup.supported_install_modes(l)
@@ -129,6 +140,14 @@ impl Settings {
 
     pub fn state_change_callback(self, s: &'static str) -> Self {
         Settings { state_change_callback: Some(s), ..self }
+    }
+
+    pub fn validate_callback(self, s: &'static str) -> Self {
+        Settings { validate_callback: Some(s), ..self }
+    }
+
+    pub fn booting_from_update(self) -> Self {
+        Settings { booting_from_update: true, ..self }
     }
 }
 


### PR DESCRIPTION
This branch intends to fix the error when coming from an existing v1 upgrade. This is done by loading the previous version context into the new data structure and then using the usual code path to run the business logic.

The following tasks need to be complete prior to merging this:

- [x] add integration tests for the v1 handling
- [x] verify if there is any missing test for the v2 handling
- [x] verify the execution on real devices
