### PR TITLE
updatehub: states: Add callback support for PrepareLocalInstall

### DIFF
--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -269,7 +269,7 @@ impl State {
             State::Probe(s) => s.handle_with_callback(context).await,
             State::Validation(s) => s.handle(context).await,
             State::DirectDownload(s) => s.handle(context).await,
-            State::PrepareLocalInstall(s) => s.handle(context).await,
+            State::PrepareLocalInstall(s) => s.handle_with_callback(context).await,
             State::Error(s) => s.handle_with_callback(context).await,
             State::Download(s) => s.handle_with_callback_and_report_progress(context).await,
             State::Install(s) => s.handle_with_callback_and_report_progress(context).await,

--- a/updatehub/src/states/prepare_local_install.rs
+++ b/updatehub/src/states/prepare_local_install.rs
@@ -4,7 +4,7 @@
 
 use super::{
     machine::{self, Context},
-    Install, Result, State, StateChangeImpl,
+    CallbackReporter, Install, Result, State, StateChangeImpl,
 };
 use crate::{
     firmware::installation_set,
@@ -22,6 +22,8 @@ use std::{
 pub(super) struct PrepareLocalInstall {
     pub(super) update_file: PathBuf,
 }
+
+impl CallbackReporter for PrepareLocalInstall {}
 
 #[async_trait::async_trait]
 impl StateChangeImpl for PrepareLocalInstall {


### PR DESCRIPTION
When doing local installations the Install state can take too long to
be triggered. Now we can check the PrepareLocalInstall for faster
feedback.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>