### PR TITLE
CI: Pin down nightly version to avoid execution erros from rexpect

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -14,7 +14,7 @@ jobs:
         name: [MSRV, stable, nightly]
         include:
           - name: MSRV
-            version: 1.49.0
+            version: 1.52.0
           - name: stable
             version: stable
           - name: nightly

--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -14,7 +14,7 @@ jobs:
         name: [MSRV, stable, nightly]
         include:
           - name: MSRV
-            version: 1.49.0
+            version: 1.52.0
           - name: stable
             version: stable
           - name: nightly

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
           - name: stable
             version: stable
           - name: nightly
-            version: nightly
+            version: nightly-2021-07-02
 
     name: Test ${{ matrix.name }} - x86_64-unknown-linux-gnu
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
         name: [MSRV, stable, nightly]
         include:
           - name: MSRV
-            version: 1.49.0
+            version: 1.52.0
           - name: stable
             version: stable
           - name: nightly


### PR DESCRIPTION
Nightly version fixed till rexpect doesn't fail on nightly. Tracking issue has been opened on: https://github.com/philippkeller/rexpect/issues/38