### PR TITLE
Migrate from async-std to tokio

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -19,7 +19,7 @@ jobs:
           - name: stable
             version: stable
           - name: nightly
-            version: nightly-2021-07-02
+            version: nightly
 
     name: Test ${{ matrix.name }} - aarch64-unknown-linux-gnu
     runs-on: ubuntu-latest

--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -19,7 +19,7 @@ jobs:
           - name: stable
             version: stable
           - name: nightly
-            version: nightly-2021-07-02
+            version: nightly
 
     name: Test ${{ matrix.name }} - armv7-unknown-linux-gnueabihf
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,16 +273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
-name = "cfb"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca453e8624711b2f0f4eb47076a318feda166252a827ee25d067b43de83dcba0"
-dependencies = [
- "byteorder",
- "uuid",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,15 +952,6 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "infer"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea70330449622910e0edebab230734569516269fb32342fb0a8956340fa48c6c"
-dependencies = [
- "cfb",
 ]
 
 [[package]]
@@ -2249,7 +2230,6 @@ dependencies = [
  "flate2",
  "futures-util",
  "git-version",
- "infer",
  "insta",
  "lazy_static",
  "logging_content",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conpty"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b306bd4a84f598049516949dc545531512c7932f2de75024dc038238aa37b30"
+dependencies = [
+ "windows",
+]
+
+[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +366,12 @@ dependencies = [
  "terminal_size",
  "winapi",
 ]
+
+[[package]]
+name = "const-sha1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
 
 [[package]]
 name = "core-foundation"
@@ -574,20 +589,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "expectrl"
+version = "0.1.3"
+source = "git+https://github.com/zhiburt/expectrl#c6bbb387300bffe30105ad7cd1b260b319c0edc8"
+dependencies = [
+ "conpty",
+ "nix 0.21.2",
+ "ptyprocess",
+ "regex",
+]
 
 [[package]]
 name = "find-binary-version"
@@ -1191,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
@@ -1204,15 +1220,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.17.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+checksum = "77d9f3521ea8e0641a153b3cddaf008dcbf26acd4ed739a2517295e0760d12c7"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "void",
+ "memoffset",
 ]
 
 [[package]]
@@ -1468,6 +1484,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptyprocess"
+version = "0.1.9"
+source = "git+https://github.com/zhiburt/ptyprocess#24b9c56de170cc3d397a97e49e0649e6f910a1f4"
+dependencies = [
+ "nix 0.21.2",
+]
+
+[[package]]
 name = "quale"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,18 +1681,6 @@ name = "result"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
-
-[[package]]
-name = "rexpect"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862c0149d91461fab225ddd06a5af919913f5c57405ed4f27d2466d6cc877186"
-dependencies = [
- "error-chain",
- "nix 0.14.1",
- "regex",
- "tempfile",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -2226,6 +2238,7 @@ dependencies = [
  "compress-tools",
  "derive_more",
  "easy_process",
+ "expectrl",
  "find-binary-version",
  "flate2",
  "futures-util",
@@ -2242,7 +2255,6 @@ dependencies = [
  "quale",
  "regex",
  "reqwest",
- "rexpect",
  "serde",
  "serde_ini",
  "serde_json",
@@ -2528,6 +2540,51 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef84dd25f4c69a271b1bba394532bf400523b43169de21dfc715e8f8e491053d"
+dependencies = [
+ "const-sha1",
+ "windows_gen",
+ "windows_macros",
+]
+
+[[package]]
+name = "windows_gen"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7bb21b8ff5e801232b72a6ff554b4cc0cef9ed9238188c3ca78fe3968a7e5d"
+dependencies = [
+ "windows_quote",
+ "windows_reader",
+]
+
+[[package]]
+name = "windows_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5566b8c51118769e4a9094a688bf1233a3f36aacbfc78f3b15817fe0b6e0442f"
+dependencies = [
+ "syn",
+ "windows_gen",
+ "windows_quote",
+ "windows_reader",
+]
+
+[[package]]
+name = "windows_quote"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af8236a9493c38855f95cdd11b38b342512a5df4ee7473cffa828b5ebb0e39c"
+
+[[package]]
+name = "windows_reader"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d5cf83fb08083438c5c46723e6206b2970da57ce314f80b57724439aaacab"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "bitar"
 version = "0.8.0"
-source = "git+https://github.com/oll3/bita#5f383dd28c122215afdf6512d685f09bfef9966f"
+source = "git+https://github.com/oll3/bita#b39a263f38c7a5c92da2ec606235e81886a26efa"
 dependencies = [
  "async-trait",
  "blake2",
@@ -1003,9 +1003,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,16 +156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +308,6 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
 dependencies = [
- "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -3060,15 +3049,15 @@ dependencies = [
 name = "updatehub-sdk"
 version = "2.0.6"
 dependencies = [
- "async-std",
  "chrono",
  "derive_more",
  "log",
  "ms-converter",
+ "reqwest",
  "serde",
- "surf",
  "tempfile",
  "testcontainers",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,60 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,84 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-dup"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
-dependencies = [
- "futures-io",
- "simple-mutex",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "futures-lite",
- "num_cpus",
- "once_cell",
- "tokio",
-]
-
-[[package]]
-name = "async-h1"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5142de15b549749cce62923a50714b0d7b77f5090ced141599e78899865451"
-dependencies = [
- "async-channel",
- "async-dup",
- "async-std",
- "byte-pool",
- "futures-core",
- "http-types",
- "httparse",
- "lazy_static",
- "log",
- "pin-project",
-]
-
-[[package]]
-name = "async-io"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
-dependencies = [
- "concurrent-queue",
- "futures-lite",
- "libc",
- "log",
- "once_cell",
- "parking",
- "polling",
- "slab",
- "socket2",
- "waker-fn",
- "winapi",
-]
-
-[[package]]
 name = "async-lock"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,80 +129,6 @@ checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-process"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21b63ab5a0db0369deb913540af2892750e42d949faacc7a61495ac418a1692"
-dependencies = [
- "async-io",
- "blocking",
- "cfg-if 1.0.0",
- "event-listener",
- "futures-lite",
- "libc",
- "once_cell",
- "signal-hook",
- "winapi",
-]
-
-[[package]]
-name = "async-sse"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bba003996b8fd22245cd0c59b869ba764188ed435392cf2796d03b805ade10"
-dependencies = [
- "async-channel",
- "async-std",
- "http-types",
- "log",
- "memchr",
- "pin-project-lite 0.1.12",
-]
-
-[[package]]
-name = "async-std"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "num_cpus",
- "once_cell",
- "pin-project-lite 0.2.7",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
@@ -346,12 +140,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -386,12 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,7 +187,7 @@ dependencies = [
  "async-trait",
  "blake2",
  "brotli-decompressor",
- "bytes 1.1.0",
+ "bytes",
  "futures-util",
  "log",
  "prost",
@@ -441,20 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "brotli-decompressor"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,32 +233,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
-name = "byte-pool"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca"
-dependencies = [
- "crossbeam-queue",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -551,17 +313,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time",
  "winapi",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -616,29 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "aes-gcm",
- "base64",
- "hkdf",
- "hmac",
- "percent-encoding",
- "rand 0.8.4",
- "sha2",
- "time 0.2.27",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,18 +386,21 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crc32fast"
@@ -683,16 +416,6 @@ name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -739,15 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,47 +469,6 @@ checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
 dependencies = [
  "nix 0.22.1",
  "winapi",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003cb79c1c6d1c93344c7e1201bb51c2148f24ec2bd9c253709d6b2efb796515"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.48+curl-7.79.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a77a741f832116da66aeb126b4f19190ecf46144a74a9bde43c2086f38da0e"
-dependencies = [
- "cc",
- "libc",
- "libnghttp2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
 ]
 
 [[package]]
@@ -850,12 +523,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dtoa"
@@ -933,15 +600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
-name = "fastrand"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "find-binary-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,17 +626,6 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bebadab126f8120d410b677ed95eee4ba6eb7c6dd8e34a5ec88a08050e26132"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spinning_top",
 ]
 
 [[package]]
@@ -1013,12 +660,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1032,34 +694,6 @@ name = "futures-io"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
-
-[[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite 0.2.7",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -1081,14 +715,10 @@ checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-core",
- "futures-io",
- "futures-macro",
+ "futures-sink",
  "futures-task",
- "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1131,16 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
 name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,25 +789,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1205,6 +812,31 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "headers"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -1231,16 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,7 +878,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1267,46 +889,9 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "http",
- "pin-project-lite 0.2.7",
-]
-
-[[package]]
-name = "http-client"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea880b03c18a7e981d7fb3608b8904a98425d53c440758fcebf7d934aa56547c"
-dependencies = [
- "async-std",
- "async-trait",
- "cfg-if 1.0.0",
- "dashmap",
- "http-types",
- "isahc",
- "log",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-std",
- "base64",
- "cookie",
- "futures-lite",
- "infer 0.2.3",
- "pin-project-lite 0.2.7",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1327,7 +912,7 @@ version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1337,7 +922,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -1351,7 +936,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
@@ -1381,17 +966,20 @@ dependencies = [
 
 [[package]]
 name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
-name = "infer"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea70330449622910e0edebab230734569516269fb32342fb0a8956340fa48c6c"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -1411,42 +999,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "isahc"
-version = "0.9.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2948a0ce43e2c2ef11d7edf6816508998d99e13badd1150be0914205df9388a"
-dependencies = [
- "bytes 0.5.6",
- "crossbeam-utils",
- "curl",
- "curl-sys",
- "flume",
- "futures-lite",
- "http",
- "log",
- "once_cell",
- "slab",
- "sluice",
- "tracing",
- "tracing-futures",
- "url",
- "waker-fn",
-]
 
 [[package]]
 name = "itertools"
@@ -1473,15 +1029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,41 +1041,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
-name = "libnghttp2-sys"
-version = "0.1.7+1.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1537,7 +1053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "value-bag",
 ]
 
 [[package]]
@@ -1656,6 +1171,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multipart"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log",
+ "mime",
+ "mime_guess",
+ "quick-error",
+ "rand 0.7.3",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
 
 [[package]]
 name = "native-tls"
@@ -1816,12 +1349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,12 +1386,6 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
-
-[[package]]
-name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
@@ -1880,30 +1401,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "polling"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "log",
- "wepoll-ffi",
- "winapi",
-]
-
-[[package]]
-name = "polyval"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
-dependencies = [
- "cpuid-bool",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1930,12 +1427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,7 +1441,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost-derive",
 ]
 
@@ -1960,7 +1451,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "heck",
  "itertools",
  "log",
@@ -1991,7 +1482,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "prost",
 ]
 
@@ -2152,7 +1643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64",
- "bytes 1.1.0",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2167,7 +1658,7 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2199,25 +1690,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "route-recognizer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustversion"
@@ -2230,6 +1706,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -2251,10 +1733,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
+name = "scoped-tls"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "security-framework"
@@ -2278,21 +1760,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2337,17 +1804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a72808528a89fa9eca23bbb6a1eb92cb639b881357269b6510f11e50c0f8a9"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,10 +1828,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
+name = "sha-1"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures 0.1.5",
+ "digest",
+ "opaque-debug",
+]
 
 [[package]]
 name = "sha2"
@@ -2385,28 +1848,9 @@ checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.2.1",
  "digest",
  "opaque-debug",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2414,15 +1858,6 @@ name = "similar"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
-
-[[package]]
-name = "simple-mutex"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
-dependencies = [
- "event-listener",
-]
 
 [[package]]
 name = "slab"
@@ -2473,17 +1908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sluice"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
-dependencies = [
- "async-channel",
- "futures-core",
- "futures-io",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,110 +1918,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning_top"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "surf"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f856d60bdb4679fc9ec516c34093484e963431b5016a8429f85a8e74b5ccaa"
-dependencies = [
- "async-std",
- "async-trait",
- "cfg-if 1.0.0",
- "futures-util",
- "getrandom 0.2.3",
- "http-client",
- "http-types",
- "log",
- "mime_guess",
- "once_cell",
- "pin-project-lite 0.2.7",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "sval"
-version = "1.0.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
 
 [[package]]
 name = "syn"
@@ -2677,53 +2001,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tide"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c459573f0dd2cc734b539047f57489ea875af8ee950860ded20cf93a79a1dee0"
-dependencies = [
- "async-h1",
- "async-sse",
- "async-std",
- "async-trait",
- "futures-util",
- "http-client",
- "http-types",
- "kv-log-macro",
- "log",
- "pin-project-lite 0.2.7",
- "route-recognizer",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2734,44 +2017,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
 ]
 
 [[package]]
@@ -2805,12 +2050,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
- "bytes 1.1.0",
+ "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "tokio-macros",
  "winapi",
 ]
@@ -2837,16 +2082,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
- "bytes 1.1.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2873,20 +2142,8 @@ checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.7",
- "tracing-attributes",
+ "pin-project-lite",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2899,20 +2156,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log",
+ "rand 0.8.4",
+ "sha-1",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "typenum"
@@ -2957,23 +2232,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "universal-hash"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "updatehub"
 version = "2.0.6"
 dependencies = [
  "argh",
+ "async-channel",
  "async-ctrlc",
  "async-lock",
- "async-std",
  "async-trait",
  "bitar",
  "chrono",
@@ -2984,7 +2249,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "git-version",
- "infer 0.5.0",
+ "infer",
  "insta",
  "lazy_static",
  "logging_content",
@@ -2996,6 +2261,7 @@ dependencies = [
  "pretty_assertions",
  "quale",
  "regex",
+ "reqwest",
  "rexpect",
  "serde",
  "serde_ini",
@@ -3004,10 +2270,8 @@ dependencies = [
  "slog-async",
  "slog-scope",
  "slog-term",
- "surf",
  "sys-mount",
  "tempfile",
- "tide",
  "timeout-readwrite",
  "tokio",
  "toml",
@@ -3016,6 +2280,7 @@ dependencies = [
  "updatehub-sdk",
  "url",
  "walkdir",
+ "warp",
 ]
 
 [[package]]
@@ -3070,25 +2335,19 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-
-[[package]]
-name = "value-bag"
-version = "1.0.0-alpha.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
-dependencies = [
- "ctor",
- "sval",
- "version_check",
-]
 
 [[package]]
 name = "vcpkg"
@@ -3109,12 +2368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,6 +2386,35 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multipart",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3223,15 +2505,6 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,12 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38de00daab4eac7d753e97697066238d67ce9d7e2d823ab4f72fe14af29f3f33"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,18 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
-dependencies = [
- "async-std",
- "native-tls",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -632,17 +614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom",
- "serde",
-]
-
-[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,20 +807,6 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
-]
-
-[[package]]
-name = "deadpool"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
-dependencies = [
- "async-trait",
- "config",
- "crossbeam-queue",
- "num_cpus",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -1067,28 +1024,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1096,17 +1037,6 @@ name = "futures-core"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1161,11 +1091,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite 0.2.7",
@@ -1361,14 +1289,10 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea880b03c18a7e981d7fb3608b8904a98425d53c440758fcebf7d934aa56547c"
 dependencies = [
- "async-h1",
- "async-native-tls",
  "async-std",
  "async-trait",
  "cfg-if 1.0.0",
  "dashmap",
- "deadpool",
- "futures",
  "http-types",
  "isahc",
  "log",
@@ -1430,6 +1354,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.1.0",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1509,12 +1446,10 @@ dependencies = [
  "crossbeam-utils",
  "curl",
  "curl-sys",
- "encoding_rs",
  "flume",
  "futures-lite",
  "http",
  "log",
- "mime",
  "once_cell",
  "slab",
  "sluice",
@@ -1562,19 +1497,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -1801,17 +1723,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -2259,16 +2170,20 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.7",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2614,12 +2529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,7 +2822,29 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite 0.2.7",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3102,18 +3033,17 @@ dependencies = [
 name = "updatehub-cloud-sdk"
 version = "2.0.6"
 dependencies = [
- "async-std",
  "derive_more",
- "http-client",
- "isahc",
  "mockito",
  "openssl",
+ "reqwest",
  "serde",
  "serde_json",
  "slog-scope",
- "surf",
  "tempfile",
+ "tokio",
  "updatehub-package-schema",
+ "url",
 ]
 
 [[package]]

--- a/updatehub-cloud-sdk/Cargo.toml
+++ b/updatehub-cloud-sdk/Cargo.toml
@@ -14,16 +14,15 @@ homepage = "https://github.com/UpdateHub/updatehub"
 documentation = "https://docs.rs/updatehub-cloud-sdk"
 
 [dependencies]
-async-std = { version = "1", default-features = false, features = ["attributes"] }
 derive_more = { version = "0.99", default-features = false, features = ["display", "error", "from"] }
-http-client = "6"
-isahc = "0.9"
 openssl = "0.10"
 pkg-schema = { path = "../updatehub-package-schema", package = "updatehub-package-schema", version = "2" }
+reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 slog-scope = "4"
-surf = { version = "2", default-features = false, features = ["curl-client"] }
+tokio = { version = "1", default-features = false, features = ["fs", "io-util", "macros"] }
+url = { version = "2", default-features = false }
 
 [dev-dependencies]
 mockito = "0.30"

--- a/updatehub-cloud-sdk/src/api.rs
+++ b/updatehub-cloud-sdk/src/api.rs
@@ -12,7 +12,7 @@ pub enum ProbeResponse {
     ExtraPoll(i64),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UpdatePackage {
     pub inner: pkg_schema::UpdatePackage,
     pub raw: Vec<u8>,

--- a/updatehub-cloud-sdk/src/client.rs
+++ b/updatehub-cloud-sdk/src/client.rs
@@ -38,7 +38,7 @@ where
     let mut written: f32 = 0.;
     let mut threshold = 10;
     let length = match resp.headers().get(header::CONTENT_LENGTH) {
-        Some(v) => usize::from_str(&v.to_str()?)?,
+        Some(v) => usize::from_str(v.to_str()?)?,
         None => 0,
     };
 

--- a/updatehub-cloud-sdk/src/lib.rs
+++ b/updatehub-cloud-sdk/src/lib.rs
@@ -23,7 +23,11 @@ pub enum Error {
     OpenSsl(openssl::error::ErrorStack),
     ParseInt(std::num::ParseIntError),
 
-    Http(#[error(not(source))] surf::Error),
+    Http(reqwest::Error),
     #[display(fmt = "Invalid status response: {}", _0)]
-    InvalidStatusResponse(#[error(not(source))] surf::StatusCode),
+    InvalidStatusResponse(#[error(not(source))] reqwest::StatusCode),
+    #[display(fmt = "Invalid header value: {}", _0)]
+    HeaderParse(reqwest::header::ToStrError),
+    #[display(fmt = "Invalid url: {}", _0)]
+    UrlParse(url::ParseError),
 }

--- a/updatehub-cloud-sdk/tests/integration_test.rs
+++ b/updatehub-cloud-sdk/tests/integration_test.rs
@@ -203,33 +203,33 @@ impl FakeMetadata {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn direct_get_invalid_url() {
-    let res = sdk::get("http://foo.bar:---", &mut async_std::io::sink()).await;
+    let res = sdk::get("http://foo.bar:---", &mut tokio::io::sink()).await;
     assert!(res.is_err());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_requirements() {
     let (url, mocks) = create_mock_server(FakeServer::NoUpdate);
     sdk::Client::new(&url).probe(0, FakeMetadata::new().get()).await.unwrap();
     mocks.iter().for_each(Mock::assert);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_invalid_url() {
     let res = sdk::Client::new("http://foo.bar:---").probe(0, FakeMetadata::new().get()).await;
     assert!(res.is_err());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_with_retry() {
     let (url, mocks) = create_mock_server(FakeServer::WithRetry);
     sdk::Client::new(&url).probe(1, FakeMetadata::new().get()).await.unwrap();
     mocks.iter().for_each(Mock::assert);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_response_with_signature() {
     use sdk::api::ProbeResponse;
     let (url, mocks) = create_mock_server(FakeServer::HasUpdate);
@@ -246,7 +246,7 @@ async fn probe_response_with_signature() {
     mocks.iter().for_each(Mock::assert);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_response_with_extra_poll() {
     use sdk::api::ProbeResponse;
     let (url, mocks) = create_mock_server(FakeServer::ExtraPoll);
@@ -258,7 +258,7 @@ async fn probe_response_with_extra_poll() {
     mocks.iter().for_each(Mock::assert);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn report_success() {
     let (url, mocks) = create_mock_server(FakeServer::ReportSuccess);
     sdk::Client::new(&url)
@@ -268,7 +268,7 @@ async fn report_success() {
     mocks.iter().for_each(Mock::assert);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn report_error() {
     let (url, mocks) = create_mock_server(FakeServer::ReportError);
     sdk::Client::new(&url)
@@ -285,9 +285,9 @@ async fn report_error() {
     mocks.iter().for_each(Mock::assert);
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn download_object() {
-    use async_std::fs;
+    use tokio::fs;
 
     let (url, mocks) = create_mock_server(FakeServer::DownloadInParts);
     let dir = tempfile::tempdir().unwrap();

--- a/updatehub-package-schema/src/copy.rs
+++ b/updatehub-package-schema/src/copy.rs
@@ -8,7 +8,7 @@ use crate::definitions::{
 use serde::Deserialize;
 use std::path::PathBuf;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Copy {
     pub filename: String,

--- a/updatehub-package-schema/src/definitions/chunk_size.rs
+++ b/updatehub-package-schema/src/definitions/chunk_size.rs
@@ -6,7 +6,7 @@ use serde::{de, Deserialize, Deserializer};
 
 /// The size of the buffers (in bytes) used to read and write,
 /// default is the 128KiB.
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct ChunkSize(pub usize);
 
 impl Default for ChunkSize {

--- a/updatehub-package-schema/src/definitions/install_if_different.rs
+++ b/updatehub-package-schema/src/definitions/install_if_different.rs
@@ -6,7 +6,7 @@ use derive_more::Display;
 use serde::Deserialize;
 
 /// Handles when an object should be installed on target.
-#[derive(PartialEq, Debug, Deserialize, Display)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Display)]
 #[serde(untagged)]
 pub enum InstallIfDifferent {
     #[serde(deserialize_with = "deserialize_checksum")]
@@ -23,7 +23,7 @@ pub enum InstallIfDifferent {
 
 /// Known patterns to be used with
 /// [`InstallIfDifferent`](InstallIfDifferent::KnownPattern)
-#[derive(PartialEq, Debug, Deserialize, Display)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Display)]
 #[serde(rename_all = "kebab-case")]
 pub enum KnownPatternKind {
     /// Linux Kernel pattern.
@@ -36,7 +36,7 @@ pub enum KnownPatternKind {
 
 /// Custom pattern to use with
 /// [`InstallIfDifferent`](InstallIfDifferent::CustomPattern)
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Pattern {
     pub regexp: String,

--- a/updatehub-package-schema/src/definitions/skip.rs
+++ b/updatehub-package-schema/src/definitions/skip.rs
@@ -5,7 +5,7 @@
 use serde::Deserialize;
 
 /// How many chunk-size blocks must be skipped in the source file
-#[derive(PartialEq, Debug, Default, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Default, Deserialize)]
 pub struct Skip(pub u64);
 
 #[cfg(test)]

--- a/updatehub-package-schema/src/definitions/target_format.rs
+++ b/updatehub-package-schema/src/definitions/target_format.rs
@@ -5,7 +5,7 @@
 use serde::Deserialize;
 
 /// Information about formatting the partition before installing.
-#[derive(PartialEq, Debug, Deserialize, Default)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TargetFormat {
     #[serde(rename = "format?", default)]

--- a/updatehub-package-schema/src/definitions/target_permissions.rs
+++ b/updatehub-package-schema/src/definitions/target_permissions.rs
@@ -5,7 +5,7 @@
 use serde::{de, Deserialize, Deserializer};
 
 /// Options to set permissions after installing on target.
-#[derive(PartialEq, Debug, Deserialize, Default)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 #[serde(default)]
 pub struct TargetPermissions {
@@ -15,7 +15,7 @@ pub struct TargetPermissions {
     pub target_uid: Option<Uid>,
 }
 
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Gid {
     /// Group name.
@@ -25,7 +25,7 @@ pub enum Gid {
     Number(u32),
 }
 
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Uid {
     /// User name.

--- a/updatehub-package-schema/src/definitions/truncate.rs
+++ b/updatehub-package-schema/src/definitions/truncate.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 /// True if the file pointed to by the `target_path` should be open in
 /// truncate mode (erase content before writing).
-#[derive(PartialEq, Debug, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize)]
 pub struct Truncate(pub bool);
 
 impl Default for Truncate {

--- a/updatehub-package-schema/src/flash.rs
+++ b/updatehub-package-schema/src/flash.rs
@@ -5,7 +5,7 @@
 use crate::definitions::{InstallIfDifferent, TargetType};
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Flash {
     pub filename: String,

--- a/updatehub-package-schema/src/imxkobs.rs
+++ b/updatehub-package-schema/src/imxkobs.rs
@@ -6,7 +6,7 @@ use crate::definitions::InstallIfDifferent;
 use serde::Deserialize;
 use std::path::PathBuf;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 pub struct Imxkobs {
     pub filename: String,
     pub size: u64,

--- a/updatehub-package-schema/src/lib.rs
+++ b/updatehub-package-schema/src/lib.rs
@@ -30,7 +30,7 @@ pub use update_package::{SupportedHardware, UpdatePackage};
 use serde::Deserialize;
 
 /// Represents the install mode for the object data
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(tag = "mode")]
 #[serde(rename_all = "lowercase")]
 pub enum Object {

--- a/updatehub-package-schema/src/mender.rs
+++ b/updatehub-package-schema/src/mender.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 pub struct Mender {
     pub filename: String,
     pub size: u64,

--- a/updatehub-package-schema/src/raw.rs
+++ b/updatehub-package-schema/src/raw.rs
@@ -5,7 +5,7 @@
 use crate::definitions::{ChunkSize, Count, InstallIfDifferent, Skip, TargetType, Truncate};
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Raw {
     pub filename: String,

--- a/updatehub-package-schema/src/raw_delta.rs
+++ b/updatehub-package-schema/src/raw_delta.rs
@@ -5,7 +5,7 @@
 use crate::definitions::{ChunkSize, TargetType};
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct RawDelta {
     pub filename: String,

--- a/updatehub-package-schema/src/tarball.rs
+++ b/updatehub-package-schema/src/tarball.rs
@@ -6,7 +6,7 @@ use crate::definitions::{Filesystem, TargetFormat, TargetType};
 use serde::Deserialize;
 use std::path::PathBuf;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Tarball {
     pub filename: String,

--- a/updatehub-package-schema/src/test.rs
+++ b/updatehub-package-schema/src/test.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Test {
     pub filename: String,

--- a/updatehub-package-schema/src/ubifs.rs
+++ b/updatehub-package-schema/src/ubifs.rs
@@ -5,7 +5,7 @@
 use crate::definitions::TargetType;
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Ubifs {
     pub filename: String,

--- a/updatehub-package-schema/src/uboot_env.rs
+++ b/updatehub-package-schema/src/uboot_env.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct UbootEnv {
     pub filename: String,

--- a/updatehub-package-schema/src/update_package.rs
+++ b/updatehub-package-schema/src/update_package.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct UpdatePackage {
     #[serde(rename = "product")]
     pub product_uid: String,
@@ -14,7 +14,7 @@ pub struct UpdatePackage {
     pub objects: (Vec<crate::Object>, Vec<crate::Object>),
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 #[serde(untagged)]
 pub enum SupportedHardware {
     #[serde(deserialize_with = "any")]

--- a/updatehub-package-schema/src/zephyr.rs
+++ b/updatehub-package-schema/src/zephyr.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Clone, Deserialize, PartialEq, Debug)]
 pub struct Zephyr {
     pub filename: String,
     pub size: u64,

--- a/updatehub-sdk/Cargo.toml
+++ b/updatehub-sdk/Cargo.toml
@@ -14,18 +14,18 @@ homepage = "https://github.com/UpdateHub/updatehub"
 documentation = "https://docs.rs/updatehub-sdk"
 
 [dependencies]
-async-std = { version = "1.6", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 derive_more = { version = "0.99", default-features = false, features = ["display", "error", "from"] }
 log = "0.4"
 ms-converter = "1"
+reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
-surf = { version = "2", default-features = false, features = ["curl-client"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "macros", "net"] }
 
 [dev-dependencies]
-async-std = { version = "1", default-features = false, features = ["attributes"] }
 tempfile = "3"
 testcontainers = "0.12"
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros"] }
 
 [[example]]
 name = "listener"

--- a/updatehub-sdk/examples/listener.rs
+++ b/updatehub-sdk/examples/listener.rs
@@ -9,7 +9,7 @@ async fn download_callback(mut handler: listener::Handler) -> Result<()> {
     handler.cancel().await
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<()> {
     let mut listener = listener::StateChange::default();
 

--- a/updatehub-sdk/src/error.rs
+++ b/updatehub-sdk/src/error.rs
@@ -17,9 +17,9 @@ pub enum Error {
     AbortDownloadRefused(#[error(not(source))] crate::api::abort_download::Refused),
 
     #[display(fmt = "Unexpected response: {:?}", _0)]
-    UnexpectedResponse(#[error(not(source))] surf::StatusCode),
+    UnexpectedResponse(#[error(not(source))] reqwest::StatusCode),
 
-    Client(#[error(not(source))] surf::Error),
+    Client(reqwest::Error),
 
     Io(std::io::Error),
 

--- a/updatehub-sdk/tests/openapi_integration.rs
+++ b/updatehub-sdk/tests/openapi_integration.rs
@@ -34,7 +34,7 @@ impl MockServer {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn info() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();
@@ -43,7 +43,7 @@ async fn info() {
     assert!(dbg!(response).is_ok());
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_default() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();
@@ -56,7 +56,7 @@ async fn probe_default() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn probe_custom() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();
@@ -69,7 +69,7 @@ async fn probe_custom() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn local_install() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();
@@ -84,7 +84,7 @@ async fn local_install() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn remote_install() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();
@@ -97,7 +97,7 @@ async fn remote_install() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn abort_download() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();
@@ -110,7 +110,7 @@ async fn abort_download() {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn log() {
     let mock = MockServer::new();
     let (addr, _guard) = &mock.start();

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -82,7 +82,7 @@ insta = { version = "1", features = ["backtrace"] }
 # Pin version as this is the last one not using bindgen
 loopdev = "=0.2.1"
 
+expectrl = { version = "0.1", git = "https://github.com/zhiburt/expectrl"}
 pretty_assertions = "0.7"
 regex = "1"
-rexpect = "0.4"
 tempfile = "3"

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -45,7 +45,6 @@ derive_more = { version = "0.99", default-features = false, features = ["deref",
 easy_process = "0.2"
 find-binary-version = "0.3"
 futures-util = { version = "0.3", default-features = false }
-infer = "0.5"
 lazy_static = "1"
 logging_content = { version = "0.1", git = "https://github.com/OSSystems/logging_content.git" }
 mockito = { version = "0.30", optional = true }

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -34,8 +34,8 @@ required-features = ["test-env"]
 [dependencies]
 argh = "0.1.3"
 async-ctrlc = { version = "1", optional = true }
+async-channel = "1"
 async-lock = "2"
-async-std = { version = "1", features = ["unstable", "tokio1"] }
 async-trait = "0.1"
 bitar = { version = "0.8", git = "https://github.com/oll3/bita" }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
@@ -55,6 +55,7 @@ openssl = "0.10"
 pkg-schema = { path = "../updatehub-package-schema", package = "updatehub-package-schema" }
 quale = "1"
 regex = { version = "1", default-features = false }
+reqwest = { version = "0.11", default-features = false, features = ["json", "native-tls"] }
 sdk = { path = "../updatehub-sdk", package = "updatehub-sdk" }
 serde = { version = "1", default-features = false, features = ["rc", "derive"] }
 serde_ini = { version = "0.2", default-features = false, optional = true }
@@ -63,15 +64,14 @@ slog = { version = "2", default-features = false, features = ["max_level_trace",
 slog-async = { version = "2", default-features = false }
 slog-scope = "4"
 slog-term = "2"
-surf = { version = "2", default-features = false, features = ["curl-client"] }
 sys-mount = { version = "1", default-features = false }
 tempfile = "3"
-tide = { version = "0.16", default-features = false, features = ["h1-server"] }
 timeout-readwrite = "0.3"
-tokio = { version = "1", default-features = false, features = ["fs"] }
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "fs", "macros"] }
 toml = "0.5"
 url = "2"
 walkdir = "2"
+warp = "0.3"
 
 [build-dependencies]
 git-version = "0.3"

--- a/updatehub/src/cloud_mock.rs
+++ b/updatehub/src/cloud_mock.rs
@@ -50,8 +50,8 @@ impl<'a> Client<'a> {
                 None,
             )),
             FakeResponse::InvalidUri => {
-                let uri_error = surf::http::Url::parse("http://foo:--").unwrap_err();
-                Err(Error::Http(surf::Error::new(surf::StatusCode::InternalServerError, uri_error)))
+                let uri_error = url::Url::parse("http://foo:--").unwrap_err();
+                Err(Error::UrlParse(uri_error))
             }
         })
     }
@@ -64,7 +64,7 @@ impl<'a> Client<'a> {
         object: &str,
     ) -> Result<()> {
         if let Some(data) = OBJECT_DATA.with(|conf| conf.borrow_mut().take()) {
-            async_std::fs::write(download_dir.join(object), data).await?
+            tokio::fs::write(download_dir.join(object), data).await?
         }
 
         Ok(())

--- a/updatehub/src/lib.rs
+++ b/updatehub/src/lib.rs
@@ -39,4 +39,5 @@ pub enum Error {
     Process(easy_process::Error),
     Sdk(sdk::Error),
     Serde(serde_json::Error),
+    AddrParseError(std::net::AddrParseError),
 }

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -249,13 +249,13 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn copy_compressed_file() {
         exec_test_with_copy(|obj| obj.compressed = true, None, true).await.unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn copy_over_formated_partion() {
         exec_test_with_copy(|obj| obj.target_format.should_format = true, None, false)
@@ -263,7 +263,7 @@ mod tests {
             .unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn copy_over_existing_file() {
         exec_test_with_copy(
@@ -279,7 +279,7 @@ mod tests {
         .unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn copy_change_uid() {
         exec_test_with_copy(
@@ -294,7 +294,7 @@ mod tests {
         .unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn copy_change_gid() {
         exec_test_with_copy(
@@ -313,7 +313,7 @@ mod tests {
         .unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn copy_change_mode() {
         exec_test_with_copy(

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -77,7 +77,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn check_requirements_with_missing_binaries() {
         let flash_obj = fake_flash_obj("system0");
         let context = Context::default();
@@ -107,7 +107,7 @@ mod tests {
         assert!(flash_obj.check_requirements(&context).await.is_err());
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn install_nor() {
         let _mtd_lock = SERIALIZE.lock();

--- a/updatehub/src/object/installer/imxkobs.rs
+++ b/updatehub/src/object/installer/imxkobs.rs
@@ -89,7 +89,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn check_requirements_with_missing_binaries() {
         let imxkobs_obj = fake_imxkobs_obj();
 
@@ -97,7 +97,7 @@ mod tests {
         assert!(imxkobs_obj.check_requirements(&Context::default()).await.is_err());
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install_no_args() {
         let mut imxkobs_obj = fake_imxkobs_obj();
         imxkobs_obj.padding_1k = false;
@@ -118,7 +118,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(calls).unwrap(), expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install_padding_1k() {
         let mut imxkobs_obj = fake_imxkobs_obj();
         imxkobs_obj.search_exponent = 0;
@@ -138,7 +138,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(calls).unwrap(), expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install_search_exponent() {
         let mut imxkobs_obj = fake_imxkobs_obj();
         imxkobs_obj.padding_1k = false;
@@ -162,7 +162,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(calls).unwrap(), expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install_chip_0() {
         let mut imxkobs_obj = fake_imxkobs_obj();
         imxkobs_obj.padding_1k = false;
@@ -186,7 +186,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(calls).unwrap(), expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install_chip_1() {
         let mut imxkobs_obj = fake_imxkobs_obj();
         imxkobs_obj.padding_1k = false;
@@ -210,7 +210,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(calls).unwrap(), expected);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install_all_fields() {
         let imxkobs_obj = fake_imxkobs_obj();
         let download_dir = tempfile::tempdir().unwrap();

--- a/updatehub/src/object/installer/raw.rs
+++ b/updatehub/src/object/installer/raw.rs
@@ -209,7 +209,7 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn raw_full_copy_compressed() {
         let size = 2048;
         let chunk_size = 8;
@@ -231,7 +231,7 @@ mod tests {
             .unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn raw_full_copy() {
         let size = 2048;
         let chunk_size = 8;
@@ -253,7 +253,7 @@ mod tests {
             .unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn raw_partial_copy_with_skip() {
         let size = 2048;
         let chunk_size = 128;
@@ -276,7 +276,7 @@ mod tests {
         check_unwritten_blocks(target_guard.as_file_mut(), 1024, 1024).unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn raw_partial_copy_with_seek() {
         let size = 2048;
         let chunk_size = 128;
@@ -299,7 +299,7 @@ mod tests {
         check_unwritten_blocks(target_guard.as_file_mut(), 0, 1024).unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn raw_partial_copy_with_count() {
         let size = 2048;
         let chunk_size = 128;

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -148,13 +148,13 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn install_over_formated_partion() {
         exec_test_with_tarball(|obj| obj.target_format.should_format = true).await.unwrap();
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn install_over_unformated_partion() {
         exec_test_with_tarball(|obj| obj.target_path = PathBuf::from("/existing_dir"))

--- a/updatehub/src/object/installer/ubifs.rs
+++ b/updatehub/src/object/installer/ubifs.rs
@@ -79,7 +79,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn check_requirements_with_missing_binaries() {
         let ubifs_obj = fake_ubifs_obj("home");
 
@@ -95,7 +95,7 @@ mod tests {
         assert!(ubifs_obj.check_requirements(&Context::default()).await.is_err());
     }
 
-    #[async_std::test]
+    #[tokio::test]
     #[ignore]
     async fn install() {
         let _mtd_lock = SERIALIZE.lock();

--- a/updatehub/src/object/installer/uboot_env.rs
+++ b/updatehub/src/object/installer/uboot_env.rs
@@ -69,7 +69,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn check_requirements_with_missing_binary() {
         let uboot_env_obj = fake_uboot_env_obj();
 
@@ -77,7 +77,7 @@ mod tests {
         assert!(uboot_env_obj.check_requirements(&Context::default()).await.is_err());
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn install() {
         let setup = crate::tests::TestEnvironment::build().add_echo_binary("fw_setenv").finish();
         let output_file = &setup.binaries.data;

--- a/updatehub/src/setup_mock_env.rs
+++ b/updatehub/src/setup_mock_env.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#[async_std::main]
+#[tokio::main]
 async fn main() {
     let setup = updatehub::tests::TestEnvironment::build()
         .server_address(mockito::server_url())

--- a/updatehub/src/states/direct_download.rs
+++ b/updatehub/src/states/direct_download.rs
@@ -8,7 +8,6 @@ use super::{
 };
 use crate::utils::log::LogContent;
 use async_lock::Mutex;
-use async_std::prelude::FutureExt;
 use slog_scope::info;
 
 #[derive(Debug)]
@@ -36,11 +35,11 @@ impl StateChangeImpl for DirectDownload {
 
         let download_future = async {
             let download_dir = context.lock().await.settings.update.download_dir.clone();
-            async_std::fs::create_dir_all(&download_dir)
+            tokio::fs::create_dir_all(&download_dir)
                 .await
                 .log_error_msg("unable to create download dir")?;
             let update_file = download_dir.join("fetched_pkg");
-            let mut file = async_std::fs::File::create(&update_file)
+            let mut file = tokio::fs::File::create(&update_file)
                 .await
                 .log_error_msg("unable to open file for fatching package")?;
             cloud::get(&self.url, &mut file).await.log_error_msg("failed to fetch package")?;
@@ -61,6 +60,15 @@ impl StateChangeImpl for DirectDownload {
             Err(super::TransitionError::CommunicationFailed)
         };
 
-        Ok((download_future.race(message_handle_future).await?, machine::StepTransition::Immediate))
+        futures_util::pin_mut!(download_future);
+        futures_util::pin_mut!(message_handle_future);
+
+        Ok((
+            futures_util::future::select(download_future, message_handle_future)
+                .await
+                .factor_first()
+                .0?,
+            machine::StepTransition::Immediate,
+        ))
     }
 }

--- a/updatehub/src/states/entry_point.rs
+++ b/updatehub/src/states/entry_point.rs
@@ -54,7 +54,7 @@ impl StateChangeImpl for EntryPoint {
 mod tests {
     use super::*;
 
-    #[async_std::test]
+    #[tokio::test]
     async fn polling_disable() {
         let setup = crate::tests::TestEnvironment::build().disable_polling().finish();
         let mut context = setup.gen_context();
@@ -65,7 +65,7 @@ mod tests {
         assert_state!(machine, Park);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn polling_enabled() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -76,7 +76,7 @@ mod tests {
         assert_state!(machine, Poll);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn forced_probe() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();

--- a/updatehub/src/states/install.rs
+++ b/updatehub/src/states/install.rs
@@ -96,7 +96,7 @@ mod test {
     use crate::update_package::tests::get_update_package;
     use pretty_assertions::assert_eq;
 
-    #[async_std::test]
+    #[tokio::test]
     async fn has_package_uid_if_succeed() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();

--- a/updatehub/src/states/machine/address.rs
+++ b/updatehub/src/states/machine/address.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 #[derive(Clone)]
 pub(crate) struct Addr {
     pub(super) message: channel::Sender<(Message, channel::Sender<super::Result<Response>>)>,
-    pub(super) waker: channel::Sender<()>,
 }
 
 #[derive(Debug)]

--- a/updatehub/src/states/machine/mod.rs
+++ b/updatehub/src/states/machine/mod.rs
@@ -249,10 +249,7 @@ impl StateMachine {
     }
 
     pub(super) fn address(&self) -> Addr {
-        Addr {
-            message: self.context.communication.sender.clone(),
-            waker: self.context.waker.sender.clone(),
-        }
+        Addr { message: self.context.communication.sender.clone() }
     }
 
     pub(super) async fn start(mut self) {

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -341,12 +341,14 @@ pub async fn run(settings: &Path) -> crate::Result<()> {
 
     let machine = machine::StateMachine::new(State::new(), settings, runtime_settings, firmware);
     let addr = machine.address();
-    // Use a local spawn since spawned file write operations can get stucked on
-    // single threaded envirements:
-    // https://github.com/async-rs/async-std/issues/973
-    async_std::task::spawn_local(machine.start());
 
-    http_api::Api::server(addr).listen(listen_socket).await?;
+    // Use a local spawn since running features are !Send
+    tokio::task::spawn_local(machine.start());
+
+    // FIXME: handle failiure to parse the listen socket
+    http_api::Api::server(addr)
+        .run(listen_socket.replace("localhost", "127.0.0.1").parse::<std::net::SocketAddr>()?)
+        .await;
 
     info!("Server has gracefully stopped");
     Ok(())

--- a/updatehub/src/states/poll.rs
+++ b/updatehub/src/states/poll.rs
@@ -47,7 +47,7 @@ mod tests {
     use super::*;
     use chrono::{Duration, Utc};
 
-    #[async_std::test]
+    #[tokio::test]
     async fn normal_delay() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -62,7 +62,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn update_in_time() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -76,7 +76,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn least_probe_in_the_future() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -34,10 +34,8 @@ impl StateChangeImpl for Probe {
             .probe(context.runtime_settings.retries(), context.firmware.as_cloud_metadata())
             .await
         {
-            Err(cloud::Error::Http(e))
-                if e.downcast_ref::<surf::http::url::ParseError>().is_some() =>
-            {
-                return Err(cloud::Error::Http(e).into());
+            Err(err @ cloud::Error::UrlParse(_)) => {
+                return Err(err.into());
             }
             Err(e) => {
                 error!("Probe failed: {}", e);
@@ -94,7 +92,7 @@ mod tests {
     use super::*;
     use crate::cloud_mock;
 
-    #[async_std::test]
+    #[tokio::test]
     async fn invalid_uri() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -109,7 +107,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn update_not_available() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -120,7 +118,7 @@ mod tests {
         assert_state!(machine, EntryPoint);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn update_available() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -131,7 +129,7 @@ mod tests {
         assert_state!(machine, Validation);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn extra_poll_interval() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();

--- a/updatehub/src/states/reboot.rs
+++ b/updatehub/src/states/reboot.rs
@@ -52,7 +52,7 @@ mod test {
     use crate::update_package::tests::get_update_package;
     use pretty_assertions::assert_eq;
 
-    #[async_std::test]
+    #[tokio::test]
     async fn runs() {
         let setup = crate::tests::TestEnvironment::build().add_echo_binary("reboot").finish();
         let mut context = setup.gen_context();

--- a/updatehub/src/states/validation.rs
+++ b/updatehub/src/states/validation.rs
@@ -102,7 +102,7 @@ mod tests {
     use super::*;
     use crate::{states::TransitionError, update_package::tests::get_update_package};
 
-    #[async_std::test]
+    #[tokio::test]
     async fn normal_transition() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -117,7 +117,7 @@ mod tests {
         assert_state!(machine, Download);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn invalid_hardware() {
         let setup = crate::tests::TestEnvironment::build().invalid_hardware().finish();
         let mut context = setup.gen_context();
@@ -133,7 +133,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn skip_same_package_uid() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();
@@ -149,7 +149,7 @@ mod tests {
         assert_state!(machine, EntryPoint);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn missing_signature() {
         let setup = crate::tests::TestEnvironment::build().finish();
         let mut context = setup.gen_context();

--- a/updatehub/src/utils/delta.rs
+++ b/updatehub/src/utils/delta.rs
@@ -96,19 +96,17 @@ where
 mod tests {
     use super::*;
 
-    #[async_std::test]
+    #[tokio::test]
     async fn test_inplace_clone() {
         // Create file with incomplete data
         let output_file = tempfile::NamedTempFile::new().unwrap();
-        async_std::fs::write(output_file.path(), "Test message sample: [...], in Rio.")
-            .await
-            .unwrap();
+        fs::write(output_file.path(), "Test message sample: [...], in Rio.").await.unwrap();
 
         clone("fixtures/message.bita", output_file.path(), 0).await.unwrap();
 
         // Assert that the file now has the full predefined message
         assert_eq!(
-            async_std::fs::read_to_string(output_file.path()).await.unwrap().as_str(),
+            fs::read_to_string(output_file.path()).await.unwrap().as_str(),
             "Test message sample: The Brazilian campaign at the Tokyo Games ended with positive results. With 21 medals, the country surpassed the record of 19 registered in 2016, in Rio.",
         );
     }

--- a/updatehub/src/utils/mtd.rs
+++ b/updatehub/src/utils/mtd.rs
@@ -206,11 +206,11 @@ pub(crate) mod tests {
 
         {
             let _mtd = FakeMtd::new(&[], MtdKind::Nand).unwrap();
-            assert_eq!(is_nand(&PathBuf::from("/dev/mtd0")).unwrap(), true);
+            assert!(is_nand(&PathBuf::from("/dev/mtd0")).unwrap());
         }
         {
             let _mtd = FakeMtd::new(&[], MtdKind::Nor).unwrap();
-            assert_eq!(is_nand(&PathBuf::from("/dev/mtd0")).unwrap(), false);
+            assert!(!is_nand(&PathBuf::from("/dev/mtd0")).unwrap());
         }
     }
 

--- a/updatehub/tests/failed_integration_test.rs
+++ b/updatehub/tests/failed_integration_test.rs
@@ -99,7 +99,8 @@ fn failing_invalid_file_config() {
     .unwrap();
 
     let (mut session, _setup) = setup.config_file(file_path).init_server();
-    let output_server = session.exp_eof().unwrap();
+    let output_server =
+        String::from_utf8_lossy(session.expect(expectrl::Eof).unwrap().first()).into_owned();
     let (output_server_trce, ..) = rewrite_log_output(output_server);
 
     insta::assert_snapshot!(output_server_trce, @r###"
@@ -126,7 +127,8 @@ fn failing_invalid_file_config() {
     .unwrap();
 
     let (mut session, _setup) = setup.config_file(file_path).init_server();
-    let output_server = session.exp_eof().unwrap();
+    let output_server =
+        String::from_utf8_lossy(session.expect(expectrl::Eof).unwrap().first()).into_owned();
     let (output_server_trce, ..) = rewrite_log_output(output_server);
 
     insta::assert_snapshot!(output_server_trce, @r###"

--- a/updatehub/tests/failed_integration_test.rs
+++ b/updatehub/tests/failed_integration_test.rs
@@ -178,13 +178,12 @@ fn failing_invalid_server_address() {
     <timestamp> DEBG receiving probe request
     "###);
 
-    insta::assert_snapshot!(remove_carriage_newline_characters(output_client), @r###"
-    Unexpected response: InternalServerError
-    "###);
+    insta::assert_snapshot!(remove_carriage_newline_characters(output_client), @"Unexpected response: 500
+");
 
     insta::assert_snapshot!(output_log, @r###"
     <timestamp> INFO Probing the server as requested by the user
-    <timestamp> ERRO Request failed with: invalid port number
+    <timestamp> ERRO Request failed with: Invalid url: invalid port number
     "###);
 }
 
@@ -326,8 +325,8 @@ fn invalid_server_response() {
     <timestamp> INFO probing server as we are in time
     <timestamp> INFO update received: 1.2 (87effe73b80453f397cee4db3c3589a8630b220876dff8fb23447315037ff96d)
     <timestamp> INFO no signature key available on device, ignoring signature validation
-    <timestamp> ERRO failed to download object from update package: Invalid status response: 501 (InvalidStatusResponse(NotImplemented))
-    <timestamp> ERRO error state reached: Invalid status response: 501
+    <timestamp> ERRO failed to download object from update package: Invalid status response: 501 Not Implemented (InvalidStatusResponse(501))
+    <timestamp> ERRO error state reached: Invalid status response: 501 Not Implemented
     <timestamp> INFO returning to machine's entry point
     "###);
 
@@ -348,9 +347,9 @@ fn invalid_server_response() {
     <timestamp> TRCE starting to handle 'download' state
     <timestamp> TRCE the following objects are missing: [("testfile", "23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4")]
     <timestamp> DEBG starting download of: testfile (23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4)
-    <timestamp> ERRO failed to download object from update package: Invalid status response: 501 (InvalidStatusResponse(NotImplemented))
+    <timestamp> ERRO failed to download object from update package: Invalid status response: 501 Not Implemented (InvalidStatusResponse(501))
     <timestamp> TRCE starting to handle 'error' state
-    <timestamp> ERRO error state reached: Invalid status response: 501
+    <timestamp> ERRO error state reached: Invalid status response: 501 Not Implemented
     <timestamp> INFO returning to machine's entry point
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is enabled
@@ -365,9 +364,9 @@ fn invalid_server_response() {
     <timestamp> TRCE starting to handle 'download' state
     <timestamp> TRCE the following objects are missing: [("testfile", "23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4")]
     <timestamp> DEBG starting download of: testfile (23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4)
-    <timestamp> ERRO failed to download object from update package: Invalid status response: 501 (InvalidStatusResponse(NotImplemented))
+    <timestamp> ERRO failed to download object from update package: Invalid status response: 501 Not Implemented (InvalidStatusResponse(501))
     <timestamp> TRCE starting to handle 'error' state
-    <timestamp> ERRO error state reached: Invalid status response: 501
+    <timestamp> ERRO error state reached: Invalid status response: 501 Not Implemented
     <timestamp> INFO returning to machine's entry point
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is enabled

--- a/updatehub/tests/successful_integration_test.rs
+++ b/updatehub/tests/successful_integration_test.rs
@@ -278,9 +278,6 @@ fn correct_config_update_polling() {
     <timestamp> DEBG starting download of: testfile (23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4)
     <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG 100% of the file has been downloaded
     <timestamp> TRCE starting to handle 'install' state
     <timestamp> INFO installing update: 1.2 (87effe73b80453f397cee4db3c3589a8630b220876dff8fb23447315037ff96d)
@@ -306,9 +303,6 @@ fn correct_config_update_polling() {
     <timestamp> TRCE starting to handle 'download' state
     <timestamp> TRCE the following objects are missing: [("testfile", "23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4")]
     <timestamp> DEBG starting download of: testfile (23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4)
-    <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG 100% of the file has been downloaded
@@ -529,7 +523,6 @@ fn correct_config_remote_install() {
     <timestamp> TRCE starting to handle 'direct_download' state
     <timestamp> INFO fetching update package directly from url: "http://127.0.0.1:1234/some-direct-package-url"
     <timestamp> DEBG 100% of the file has been downloaded
-    <timestamp> DEBG 100% of the file has been downloaded
     <timestamp> TRCE starting to handle 'prepare_local_install' state
     <timestamp> INFO installing local package: "<file>"
     <timestamp> DEBG successfuly uncompressed metadata file
@@ -559,7 +552,6 @@ fn correct_config_remote_install() {
     insta::assert_snapshot!(output_log, @r###"
     <timestamp> TRCE starting to handle 'direct_download' state
     <timestamp> INFO fetching update package directly from url: "http://127.0.0.1:1234/some-direct-package-url"
-    <timestamp> DEBG 100% of the file has been downloaded
     <timestamp> DEBG 100% of the file has been downloaded
     <timestamp> TRCE starting to handle 'prepare_local_install' state
     <timestamp> INFO installing local package: "<file>"


### PR DESCRIPTION
Since some major dependencies really specifically on `tokio` (like `bita`), in order to reduce binary size, we are opting into moving fully into the `tokio` async tree. `surf` has been migrated to `reqwest`, `tide` has been moved to warp and some futures utilities are now called from `futures-util`.