### PR TITLE
Improve probe callback handling

### DIFF
--- a/updatehub/src/states/machine/mod.rs
+++ b/updatehub/src/states/machine/mod.rs
@@ -297,7 +297,7 @@ impl StateMachine {
                         std::result::Result::<_, async_channel::RecvError>::Ok(())
                     };
 
-                    // recv_fut dones't need to be pinned as it doesn't capture any context
+                    // recv_fut doesn't need to be pinned as it doesn't capture any context
                     futures_util::pin_mut!(comm_fut);
                     let _ = futures_util::future::select(recv_fut, comm_fut).await;
                 }

--- a/updatehub/src/states/machine/mod.rs
+++ b/updatehub/src/states/machine/mod.rs
@@ -272,7 +272,7 @@ impl StateMachine {
                     trace!("delaying transition for: {} seconds", t.num_seconds());
                     let waker = self.context.waker.receiver.clone();
 
-                    let sleep_fut = tokio::time::sleep(t.to_std().unwrap());
+                    let sleep_fut = tokio::time::sleep(t.to_std().unwrap_or_default());
                     let waker_fut = async {
                         let _ = waker.recv().await;
                     };

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -103,18 +103,18 @@ trait CallbackReporter: Sized + StateChangeImpl {
             Ok(Transition::Continue) => return self.handle(context).await,
             Ok(Transition::Cancel) => {
                 info!(
-                    "cancelling transition to '{}' due to state change callback request",
+                    "canceling transition to '{}' due to state change callback request",
                     self.name()
                 );
 
                 self.handle_on_transition_cancel(context).await
-                    .unwrap_or_else(|e| error!("failed calling specialized handler for cancelling transition to '{}' as state change callback has failed with: {}",
+                    .unwrap_or_else(|e| error!("failed calling specialized handler for canceling transition to '{}' as state change callback has failed with: {}",
                                                self.name(),
                                                e));
             }
             Err(e) => {
                 error!(
-                    "cancelling transition to '{}' as state change callback has failed with: {}",
+                    "canceling transition to '{}' as state change callback has failed with: {}",
                     self.name(),
                     e
                 );
@@ -195,7 +195,7 @@ trait ProgressReporter: CallbackReporter {
             Transition::Continue => Ok(self.handle_and_report_progress(context).await?),
             Transition::Cancel => {
                 info!(
-                    "cancelling transition to '{}' due to state change callback request",
+                    "canceling transition to '{}' due to state change callback request",
                     self.name()
                 );
                 Ok((State::EntryPoint(EntryPoint {}), machine::StepTransition::Immediate))

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -84,6 +84,14 @@ trait StateChangeImpl {
 
 #[async_trait(?Send)]
 trait CallbackReporter: Sized + StateChangeImpl {
+    async fn handle_on_transition_cancel(&self, _context: &mut machine::Context) -> Result<()> {
+        Ok(())
+    }
+
+    async fn handle_on_error(&self, _context: &mut machine::Context) -> Result<()> {
+        Ok(())
+    }
+
     async fn handle_with_callback(
         self,
         context: &mut machine::Context,
@@ -92,13 +100,17 @@ trait CallbackReporter: Sized + StateChangeImpl {
             firmware::state_change_callback(&context.settings.firmware.metadata, self.name());
 
         match transition {
-            Ok(Transition::Continue) => Ok(self.handle(context).await?),
+            Ok(Transition::Continue) => return self.handle(context).await,
             Ok(Transition::Cancel) => {
                 info!(
                     "cancelling transition to '{}' due to state change callback request",
                     self.name()
                 );
-                Ok((State::EntryPoint(EntryPoint {}), machine::StepTransition::Immediate))
+
+                self.handle_on_transition_cancel(context).await
+                    .unwrap_or_else(|e| error!("failed calling specialized handler for cancelling transition to '{}' as state change callback has failed with: {}",
+                                               self.name(),
+                                               e));
             }
             Err(e) => {
                 error!(
@@ -106,9 +118,15 @@ trait CallbackReporter: Sized + StateChangeImpl {
                     self.name(),
                     e
                 );
-                Ok((State::EntryPoint(EntryPoint {}), machine::StepTransition::Immediate))
+
+                self.handle_on_error(context).await
+                    .unwrap_or_else(|e| error!("failed calling specialized handler for transition error to '{}' as state change callback has failed with: {}",
+                                               self.name(),
+                                               e));
             }
         }
+
+        Ok((State::EntryPoint(EntryPoint {}), machine::StepTransition::Immediate))
     }
 }
 

--- a/updatehub/tests/failed_integration_test.rs
+++ b/updatehub/tests/failed_integration_test.rs
@@ -401,7 +401,7 @@ exit 1
     <timestamp> ERRO download callback has failed with status: exit status: 1
     <timestamp> INFO running state change callback for 'error' state
     <timestamp> ERRO error callback has failed with status: exit status: 1
-    <timestamp> ERRO cancelling transition to 'error' as state change callback has failed with: status: Some(1) stdout: "" stderr: ""
+    <timestamp> ERRO canceling transition to 'error' as state change callback has failed with: status: Some(1) stdout: "" stderr: ""
     <timestamp> INFO parking state machine
     "###);
 
@@ -420,7 +420,7 @@ exit 1
     <timestamp> TRCE starting to handle 'error' state
     <timestamp> INFO running state change callback for 'error' state
     <timestamp> ERRO error callback has failed with status: exit status: 1
-    <timestamp> ERRO cancelling transition to 'error' as state change callback has failed with: status: Some(1) stdout: "" stderr: ""
+    <timestamp> ERRO canceling transition to 'error' as state change callback has failed with: status: Some(1) stdout: "" stderr: ""
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is disabled
     <timestamp> TRCE starting to handle 'park' state
@@ -440,7 +440,7 @@ exit 1
     <timestamp> TRCE starting to handle 'error' state
     <timestamp> INFO running state change callback for 'error' state
     <timestamp> ERRO error callback has failed with status: exit status: 1
-    <timestamp> ERRO cancelling transition to 'error' as state change callback has failed with: status: Some(1) stdout: "" stderr: ""
+    <timestamp> ERRO canceling transition to 'error' as state change callback has failed with: status: Some(1) stdout: "" stderr: ""
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is disabled
     <timestamp> TRCE starting to handle 'park' state

--- a/updatehub/tests/successful_integration_test.rs
+++ b/updatehub/tests/successful_integration_test.rs
@@ -351,7 +351,7 @@ fn correct_config_statechange_callback() {
     <timestamp> INFO no signature key available on device, ignoring signature validation
     <timestamp> INFO running state change callback for 'download' state
     <timestamp> INFO download callback has exit with success
-    <timestamp> INFO cancelling transition to 'download' due to state change callback request
+    <timestamp> INFO canceling transition to 'download' due to state change callback request
     "###);
 
     insta::assert_snapshot!(output_server_trce, @r###"
@@ -373,7 +373,7 @@ fn correct_config_statechange_callback() {
     <timestamp> TRCE starting to handle 'download' state
     <timestamp> INFO running state change callback for 'download' state
     <timestamp> INFO download callback has exit with success
-    <timestamp> INFO cancelling transition to 'download' due to state change callback request
+    <timestamp> INFO canceling transition to 'download' due to state change callback request
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is enabled
     <timestamp> TRCE starting to handle 'poll' state
@@ -387,7 +387,7 @@ fn correct_config_statechange_callback() {
     <timestamp> TRCE starting to handle 'download' state
     <timestamp> INFO running state change callback for 'download' state
     <timestamp> INFO download callback has exit with success
-    <timestamp> INFO cancelling transition to 'download' due to state change callback request
+    <timestamp> INFO canceling transition to 'download' due to state change callback request
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is enabled
     <timestamp> TRCE starting to handle 'poll' state
@@ -425,7 +425,7 @@ fn correct_config_error_state_callback() {
     <timestamp> ERRO update package: 1.2 (fb21b217cb83e8af368c773eb13bad0a94e1b0088c6bf561072decf3c1ae9df3) has failed to meet the install requirements
     <timestamp> INFO running state change callback for 'error' state
     <timestamp> INFO error callback has exit with success
-    <timestamp> INFO cancelling transition to 'error' due to state change callback request
+    <timestamp> INFO canceling transition to 'error' due to state change callback request
     "###);
 
     insta::assert_snapshot!(output_server_trce, @r###"
@@ -448,7 +448,7 @@ fn correct_config_error_state_callback() {
     <timestamp> TRCE starting to handle 'error' state
     <timestamp> INFO running state change callback for 'error' state
     <timestamp> INFO error callback has exit with success
-    <timestamp> INFO cancelling transition to 'error' due to state change callback request
+    <timestamp> INFO canceling transition to 'error' due to state change callback request
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is enabled
     <timestamp> TRCE starting to handle 'poll' state
@@ -463,7 +463,7 @@ fn correct_config_error_state_callback() {
     <timestamp> TRCE starting to handle 'error' state
     <timestamp> INFO running state change callback for 'error' state
     <timestamp> INFO error callback has exit with success
-    <timestamp> INFO cancelling transition to 'error' due to state change callback request
+    <timestamp> INFO canceling transition to 'error' due to state change callback request
     <timestamp> TRCE starting to handle 'entry_point' state
     <timestamp> DEBG polling is enabled
     <timestamp> TRCE starting to handle 'poll' state


### PR DESCRIPTION
- updatehub: states: probe: set last polling when state is cancelled
- updatehub: states: machine: fix typo
- updatehub: states: machine: use 0 seconds as delaying default time
- updatehub: fix spelling of 'canceling' in error messages
