### PR TITLE
fix: measure the install target's own capacity, not the devtmpfs holding its node

### DIFF
--- a/updatehub/src/object/installer/mod.rs
+++ b/updatehub/src/object/installer/mod.rs
@@ -129,7 +129,7 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use lazy_static::lazy_static;
     use std::{

--- a/updatehub/src/utils/fs.rs
+++ b/updatehub/src/utils/fs.rs
@@ -9,7 +9,7 @@ use pkg_schema::definitions::{
     target_permissions::{Gid, Uid},
 };
 use slog_scope::trace;
-use std::{io, path::Path};
+use std::{io, io::Seek, os::unix::fs::FileTypeExt, path::Path};
 use sys_mount::{Mount, Unmount, UnmountDrop};
 
 pub(crate) struct MountGuard {
@@ -25,16 +25,36 @@ impl MountGuard {
 
 pub(crate) fn ensure_disk_space(target: &Path, required: u64) -> Result<()> {
     trace!("looking for {} free bytes on {:?}", required, target);
-    let stat = nix::sys::statvfs::statvfs(target)?;
-
-    // stat fields might be 32 or 64 bytes depending on host arch
-    #[allow(clippy::useless_conversion)]
-    let available = u64::from(stat.block_size() * stat.blocks_free());
+    let available = available_space(target)?;
 
     if required > available {
         return Err(Error::NotEnoughSpace { available, required });
     }
     Ok(())
+}
+
+/// Returns how many bytes may be written to `target`.
+///
+/// `statvfs` reports on the filesystem holding the given path, so pointing it
+/// at a device node measures the devtmpfs mounted on `/dev` -- which is sized
+/// after the available RAM -- instead of the device the objects are installed
+/// onto. Device nodes are therefore asked for their own capacity, which a seek
+/// to the end reports for block, MTD and UBI volume devices alike.
+fn available_space(target: &Path) -> Result<u64> {
+    let file_type = std::fs::metadata(target)?.file_type();
+
+    if file_type.is_block_device() || file_type.is_char_device() {
+        trace!("{:?} is a device node, asking it for its capacity", target);
+        return Ok(std::fs::File::open(target)?.seek(io::SeekFrom::End(0))?);
+    }
+
+    let stat = nix::sys::statvfs::statvfs(target)?;
+
+    // stat fields might be 32 or 64 bits wide depending on the host arch, so widen
+    // them before multiplying to keep filesystems bigger than 4 GiB from
+    // overflowing on 32 bit targets
+    #[allow(clippy::useless_conversion)]
+    Ok(u64::from(stat.fragment_size()) * u64::from(stat.blocks_free()))
 }
 
 pub(crate) fn is_executable_in_path(cmd: &str) -> Result<()> {
@@ -101,4 +121,87 @@ pub(crate) fn chown(path: &Path, uid: &Option<Uid>, gid: &Option<Gid>) -> Result
         uid.as_ref().map(|id| nix::unistd::Uid::from_raw(id.as_u32())),
         gid.as_ref().map(|id| nix::unistd::Gid::from_raw(id.as_u32())),
     )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::installer::tests::SERIALIZE;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    // Big enough to tell a loop device apart from the devtmpfs on /dev, small
+    // enough to stay sparse on any builder.
+    const LOOP_DEVICE_SIZE: u64 = 64 * 1024 * 1024;
+
+    struct FakeLoopDevice {
+        loopdev: loopdev::LoopDevice,
+        device: PathBuf,
+        _backing_file: tempfile::NamedTempFile,
+    }
+
+    impl FakeLoopDevice {
+        fn new(size: u64) -> Result<FakeLoopDevice> {
+            let backing_file = tempfile::NamedTempFile::new()?;
+            backing_file.as_file().set_len(size)?;
+
+            // Loop device next_free is not thread safe
+            let mutex = SERIALIZE.clone();
+            let _mutex = mutex.lock().unwrap();
+            let loopdev = loopdev::LoopControl::open()?.next_free()?;
+            let device = loopdev.path().unwrap();
+            loopdev.attach_file(backing_file.path())?;
+
+            Ok(FakeLoopDevice { loopdev, device, _backing_file: backing_file })
+        }
+    }
+
+    impl Drop for FakeLoopDevice {
+        fn drop(&mut self) {
+            if let Err(e) = self.loopdev.detach() {
+                eprintln!("Failed to cleanup FakeLoopDevice, Error: {e}");
+            }
+        }
+    }
+
+    #[test]
+    fn regular_files_are_measured_by_their_filesystem() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("object");
+        std::fs::write(&file, [0; 16]).unwrap();
+
+        // The seek a device node is asked for would answer with the file's own
+        // 16 bytes instead.
+        assert!(available_space(&file).unwrap() > 16);
+    }
+
+    #[test]
+    fn a_requirement_beyond_the_available_space_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let available = available_space(dir.path()).unwrap();
+
+        ensure_disk_space(dir.path(), available).unwrap();
+        assert!(matches!(
+            ensure_disk_space(dir.path(), available + 1),
+            Err(Error::NotEnoughSpace { .. })
+        ));
+    }
+
+    // Requires root, as creating a loop device does.
+    #[test]
+    #[ignore]
+    fn device_nodes_are_measured_by_their_own_capacity() {
+        let loop_device = FakeLoopDevice::new(LOOP_DEVICE_SIZE).unwrap();
+
+        // Asking for the directory holding the node is asking the devtmpfs mounted
+        // on /dev, which is the answer the check used to settle for.
+        assert_ne!(available_space(Path::new("/dev")).unwrap(), LOOP_DEVICE_SIZE);
+
+        assert_eq!(available_space(&loop_device.device).unwrap(), LOOP_DEVICE_SIZE);
+        ensure_disk_space(&loop_device.device, LOOP_DEVICE_SIZE).unwrap();
+        assert!(matches!(
+            ensure_disk_space(&loop_device.device, LOOP_DEVICE_SIZE + 1),
+            Err(Error::NotEnoughSpace { .. })
+        ));
+    }
 }


### PR DESCRIPTION
Closes #409.

## The bug

`ensure_disk_space()` checked free space with `statvfs(target)`, but every caller passes a **device node** — `/dev/mmcblk0p2` for `raw`/`copy`, an MTD character device for `flash`, a UBI volume for `ubifs`. `statvfs` reports on the filesystem *holding* the path it is given, and for anything under `/dev` that is the devtmpfs the kernel sizes after available RAM. The check never once looked at the partition being written to.

Measured on a development machine — three very different devices, one identical number, and that number is `df /dev`:

```
                 lseek END        statvfs available
/dev/nvme0n1     2000398934016    3365040128
/dev/nvme0n1p1     535822336      3365040128
/dev/sda         15610576896      3365040128

$ df -h /dev
devtmpfs  3.2G  0  3.2G  0%  /dev
```

This confirms the diagnosis @je-s reached in #409. It also explains why the reporter only hit it after growing their partitions: the rootfs used to be smaller than devtmpfs, so the meaningless comparison happened to pass. At a 10 GiB `required_uncompressed_size` it no longer did.

The failure is symmetric, and the other direction is the more dangerous one: a device too small for the update is accepted whenever RAM happens to exceed the object size.

## The fix

Device nodes are asked for their own capacity by seeking to the end, which block devices, MTD character devices and UBI volumes all answer with their size. That is portable in a way the ioctls are not — `BLKGETSIZE64` is declared in terms of `size_t`, so its request number differs between 32- and 64-bit userspace while the kernel writes back 64 bits either way, and MTD and UBI would each need an ioctl of their own besides. Paths that really do live on a filesystem keep going through `statvfs`.

A second fix on the same line: the `statvfs` fields are `c_ulong`/`fsblkcnt_t`, 32-bit on the armv7 targets this runs on, so the product wrapped for any filesystem past 4 GiB and the `u64` conversion came too late to help. Both operands are widened first now, and the count is taken in units of `f_frsize` rather than `f_bsize`, which is what `f_bfree` is expressed in.

## Tests

Two unit tests cover the `statvfs` path and the rejection behaviour. A third sets up a loop device and asserts the reported capacity is the device's own 64 MiB and not devtmpfs's free space — it needs root, as creating a loop device does, so it is marked `#[ignore]` alongside the MTD tests that already are. Run under `sudo`:

```
test utils::fs::tests::device_nodes_are_measured_by_their_own_capacity ... ok
```

`cargo fmt --check`, `cargo clippy --all-features --all --tests` and the full suite (157 passed) are clean.

## Left for later

`copy` and `tarball` mount a filesystem onto the target and write files into it, so the device's capacity is an upper bound for them rather than an answer — it ignores both what is already there and the filesystem's own overhead. Measuring those properly means a `statvfs` on the mount point once mounted, which is a change of its own. They are still far better off than measuring devtmpfs.