### PR TITLE
ci: let dependabot see the whole workspace, and its lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,11 @@
 version: 2
-updates:
-  - package-ecosystem: "cargo"
-    directory: "/updatehub"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "agent"
 
+# The crates form a single cargo workspace sharing one lockfile at the root, so
+# they are updated as a unit. Scoping an entry to a member directory would let
+# dependabot bump that crate's manifest without the lockfile it does not hold,
+# which every CI step then rejects for running cargo with --locked.
 updates:
   - package-ecosystem: "cargo"
-    directory: "/updatehub-cloud-sdk"
+    directory: "/"
     schedule:
       interval: "daily"
-    commit-message:
-      prefix: "cloud-sdk"
-
-updates:
-  - package-ecosystem: "cargo"
-    directory: "/updatehub-package-schema"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "package-schema"
-
-updates:
-  - package-ecosystem: "cargo"
-    directory: "/updatehub-sdk"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "sdk"


### PR DESCRIPTION
Found while diagnosing why #435 fails CI. Two separate faults, one fix.

## 1. Three of the four entries were never read

`.github/dependabot.yml` declared the top-level key `updates` **four times** — once per crate. A YAML mapping holds a key once, so the last occurrence wins and the first three are discarded during parsing, before dependabot sees them:

```console
$ yq '.updates | length' .github/dependabot.yml
1
$ yq '.updates[].directory' .github/dependabot.yml
/updatehub-sdk
```

The commit record agrees. Every dependabot commit carrying a per-crate prefix is an `sdk:` one; there has never been a single `agent:`, `cloud-sdk:` or `package-schema:` commit. So `updatehub`, `updatehub-cloud-sdk` and `updatehub-package-schema` have had no dependency updates for as long as this config has been in place.

## 2. The surviving entry could not update the lockfile

The crates form one cargo workspace and share a single `Cargo.lock` at the repository root. An entry scoped to `directory: "/updatehub-sdk"` finds no lockfile in that directory, so it bumps the crate's manifest and leaves the lockfile pinned to the old version.

Every CI step runs cargo with `--locked`, which then refuses to reconcile the two:

```
error: the lock file /home/runner/work/updatehub/updatehub/Cargo.lock
needs to be updated but --locked was passed to prevent this
```

That is exactly how #435 fails — both `code_style` and `Test` die on that line before compiling anything. It is systemic, not specific to that PR: any manifest-only bump would fail the same way.

## The fix

A single entry on the workspace root. All four crates are watched again, and the manifest and lockfile always move together.

The per-crate `commit-message.prefix` settings go away with the split entries — a workspace-wide update belongs to no one crate. Dependabot falls back to its default `build(deps)` prefix, which is what the 14 older dependabot commits in this repository already use.

## Verification

The new file parses to what it should:

```console
$ yq -o=json '.' .github/dependabot.yml
{"version": 2, "updates": [{"package-ecosystem": "cargo", "directory": "/", "schedule": {"interval": "daily"}}]}
```

I have not been able to observe dependabot acting on the new config — that only shows up on its next scheduled run.