### PR TITLE
refactor: replace async-trait with native async functions in traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,7 +3381,6 @@ dependencies = [
  "async-channel",
  "async-ctrlc",
  "async-lock",
- "async-trait",
  "bitar",
  "chrono",
  "compress-tools 0.16.1",

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -40,7 +40,6 @@ argh = "0.1.3"
 async-ctrlc = { version = "1", optional = true }
 async-channel = "2"
 async-lock = "3"
-async-trait = "0.1"
 bitar = "0.14"
 chrono = { version = "0.4", default-features = false, features = [
   "clock",

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -19,7 +19,6 @@ use tokio::{
     io::{self, AsyncWriteExt},
 };
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Copy {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'copy' handle checking requirements");

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -14,7 +14,6 @@ use crate::{
 use pkg_schema::{definitions, objects};
 use slog_scope::info;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Flash {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'flash' handle checking requirements");

--- a/updatehub/src/object/installer/imxkobs.rs
+++ b/updatehub/src/object/installer/imxkobs.rs
@@ -20,7 +20,6 @@ fn chip_0_path(obj: &objects::Imxkobs) -> PathBuf {
     obj.chip_0_device_path.clone().unwrap_or_else(|| PathBuf::from(DEFAULT_CHIP_0_DEVICE_PATH))
 }
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Imxkobs {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'imxkobs' handle checking requirements");

--- a/updatehub/src/object/installer/mender.rs
+++ b/updatehub/src/object/installer/mender.rs
@@ -7,7 +7,6 @@ use crate::object::Installer;
 use pkg_schema::objects;
 use slog_scope::warn;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Mender {
     async fn check_requirements(&self, _: &Context) -> super::Result<()> {
         warn!("'mender' objects are not supported");

--- a/updatehub/src/object/installer/mod.rs
+++ b/updatehub/src/object/installer/mod.rs
@@ -29,7 +29,6 @@ pub(crate) struct Context {
     pub(crate) base_url: String,
 }
 
-#[async_trait::async_trait(?Send)]
 pub(crate) trait Installer {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         debug!("running default check_requirements");
@@ -39,7 +38,6 @@ pub(crate) trait Installer {
     async fn install(&self, context: &Context) -> Result<()>;
 }
 
-#[async_trait::async_trait(?Send)]
 impl Installer for Object {
     async fn check_requirements(&self, context: &Context) -> Result<()> {
         for_any_object!(self, o, { o.check_requirements(context).await })

--- a/updatehub/src/object/installer/raw.rs
+++ b/updatehub/src/object/installer/raw.rs
@@ -20,7 +20,6 @@ use tokio::{
 };
 use tokio_take_seek::AsyncTakeSeekExt;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Raw {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'raw' handle checking requirements");

--- a/updatehub/src/object/installer/raw_delta.rs
+++ b/updatehub/src/object/installer/raw_delta.rs
@@ -16,7 +16,6 @@ use crate::{
 use pkg_schema::{definitions, objects};
 use slog_scope::info;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::RawDelta {
     async fn check_requirements(&self, context: &Context) -> Result<()> {
         info!("'raw-delta' handle checking requirements");

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -14,7 +14,6 @@ use crate::{
 use pkg_schema::{definitions, objects};
 use slog_scope::info;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Tarball {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'tarball' handle checking requirements");

--- a/updatehub/src/object/installer/test.rs
+++ b/updatehub/src/object/installer/test.rs
@@ -6,7 +6,6 @@ use super::Context;
 use crate::object::Installer;
 use pkg_schema::objects;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Test {
     async fn check_requirements(&self, _: &Context) -> super::Result<()> {
         if self.force_check_requirements_fail {

--- a/updatehub/src/object/installer/ubifs.rs
+++ b/updatehub/src/object/installer/ubifs.rs
@@ -14,7 +14,6 @@ use crate::{
 use pkg_schema::{definitions, objects};
 use slog_scope::info;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Ubifs {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'ubifs' handle checking requirements");

--- a/updatehub/src/object/installer/uboot_env.rs
+++ b/updatehub/src/object/installer/uboot_env.rs
@@ -12,7 +12,6 @@ use pkg_schema::{definitions, objects};
 use slog_scope::info;
 use tokio::{fs, io};
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::UbootEnv {
     async fn check_requirements(&self, _: &Context) -> Result<()> {
         info!("'uboot-env' handle checking requirements");

--- a/updatehub/src/object/installer/zephyr.rs
+++ b/updatehub/src/object/installer/zephyr.rs
@@ -7,7 +7,6 @@ use crate::object::Installer;
 use pkg_schema::objects;
 use slog_scope::warn;
 
-#[async_trait::async_trait(?Send)]
 impl Installer for objects::Zephyr {
     async fn check_requirements(&self, _: &Context) -> super::Result<()> {
         warn!("'zephyr' objects are not supported");

--- a/updatehub/src/states/direct_download.rs
+++ b/updatehub/src/states/direct_download.rs
@@ -17,7 +17,6 @@ pub(super) struct DirectDownload {
 
 impl CommunicationState for DirectDownload {}
 
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for DirectDownload {
     fn name(&self) -> &'static str {
         "direct_download"

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -115,7 +115,6 @@ impl ProgressReporter for Download {
 
 impl CommunicationState for Download {}
 
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Download {
     fn name(&self) -> &'static str {
         "download"
@@ -125,7 +124,7 @@ impl StateChangeImpl for Download {
         true
     }
 
-    async fn handle(mut self, context: &mut Context) -> Result<(State, machine::StepTransition)> {
+    async fn handle(self, context: &mut Context) -> Result<(State, machine::StepTransition)> {
         use std::ops::DerefMut;
         let communication_receiver = &context.communication.receiver.clone();
         let context = Mutex::new(context);

--- a/updatehub/src/states/entry_point.rs
+++ b/updatehub/src/states/entry_point.rs
@@ -17,7 +17,6 @@ pub(super) struct EntryPoint {}
 ///
 /// If polling is disabled it stays in `State<EntryPoint>`, otherwise, it moves
 /// to `State<Poll>` state.
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for EntryPoint {
     fn name(&self) -> &'static str {
         "entry_point"

--- a/updatehub/src/states/error.rs
+++ b/updatehub/src/states/error.rs
@@ -16,7 +16,6 @@ pub(super) struct Error {
 
 impl CallbackReporter for Error {}
 
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Error {
     fn name(&self) -> &'static str {
         "error"

--- a/updatehub/src/states/install.rs
+++ b/updatehub/src/states/install.rs
@@ -36,7 +36,6 @@ impl ProgressReporter for Install {
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Install {
     fn name(&self) -> &'static str {
         "install"

--- a/updatehub/src/states/machine/mod.rs
+++ b/updatehub/src/states/machine/mod.rs
@@ -42,7 +42,6 @@ impl<T> Channel<T> {
 
 impl CommunicationState for State {}
 
-#[async_trait::async_trait]
 pub(super) trait CommunicationState: StateChangeImpl {
     async fn handle_communication(
         &self,

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -31,7 +31,6 @@ use crate::{
     runtime_settings::RuntimeSettings,
     settings::Settings,
 };
-use async_trait::async_trait;
 use derive_more::{Display, Error, From};
 use slog_scope::{error, info, trace, warn};
 use std::path::Path;
@@ -59,12 +58,13 @@ pub enum TransitionError {
     Process(easy_process::Error),
 }
 
-#[async_trait(?Send)]
 trait StateChangeImpl {
     async fn handle(
         self,
         context: &mut machine::Context,
-    ) -> Result<(State, machine::StepTransition)>;
+    ) -> Result<(State, machine::StepTransition)>
+    where
+        Self: Sized;
 
     fn name(&self) -> &'static str;
 
@@ -82,7 +82,6 @@ trait StateChangeImpl {
     }
 }
 
-#[async_trait(?Send)]
 trait CallbackReporter: Sized + StateChangeImpl {
     async fn handle_on_transition_cancel(&self, _context: &mut machine::Context) -> Result<()> {
         Ok(())
@@ -132,7 +131,6 @@ trait CallbackReporter: Sized + StateChangeImpl {
     }
 }
 
-#[async_trait(?Send)]
 trait ProgressReporter: CallbackReporter {
     fn package_uid(&self) -> String;
     fn report_enter_state_name(&self) -> &'static str;
@@ -259,7 +257,6 @@ fn handle_startup_callbacks(
     Ok(())
 }
 
-#[async_trait(?Send)]
 impl StateChangeImpl for State {
     async fn handle(self, st: &mut machine::Context) -> Result<(State, machine::StepTransition)> {
         trace!("starting to handle '{}' state", self.name());

--- a/updatehub/src/states/park.rs
+++ b/updatehub/src/states/park.rs
@@ -13,7 +13,6 @@ pub(super) struct Park {}
 
 /// Implements the state change for `State<Park>`. It stays in
 /// `State<Park>` state.
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Park {
     fn name(&self) -> &'static str {
         "park"

--- a/updatehub/src/states/poll.rs
+++ b/updatehub/src/states/poll.rs
@@ -15,7 +15,6 @@ pub(super) struct Poll {}
 /// Implements the state change for `State<Poll>`.
 ///
 /// This state is used to control when to go to the `State<Probe>`.
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Poll {
     fn name(&self) -> &'static str {
         "poll"

--- a/updatehub/src/states/prepare_local_install.rs
+++ b/updatehub/src/states/prepare_local_install.rs
@@ -26,7 +26,6 @@ pub(super) struct PrepareLocalInstall {
 
 impl CallbackReporter for PrepareLocalInstall {}
 
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for PrepareLocalInstall {
     fn name(&self) -> &'static str {
         "prepare_local_install"

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -33,7 +33,6 @@ fn retry_delay(retries: usize, polling_interval: Duration) -> Duration {
     Duration::seconds(exponential.min(cap))
 }
 
-#[async_trait::async_trait(?Send)]
 impl CallbackReporter for Probe {
     async fn handle_on_transition_cancel(&self, context: &mut machine::Context) -> Result<()> {
         // Set the last polling time or we loop forever as polling interval will not be
@@ -52,7 +51,6 @@ impl CallbackReporter for Probe {
 }
 
 /// Implements the state change for State<Probe>.
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Probe {
     fn name(&self) -> &'static str {
         "probe"

--- a/updatehub/src/states/reboot.rs
+++ b/updatehub/src/states/reboot.rs
@@ -30,7 +30,6 @@ impl ProgressReporter for Reboot {
     }
 }
 
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Reboot {
     fn name(&self) -> &'static str {
         "reboot"

--- a/updatehub/src/states/validation.rs
+++ b/updatehub/src/states/validation.rs
@@ -22,7 +22,6 @@ pub(super) struct Validation {
 }
 
 /// Implements the state change for State<Validation>.
-#[async_trait::async_trait(?Send)]
 impl StateChangeImpl for Validation {
     fn name(&self) -> &'static str {
         "validation"


### PR DESCRIPTION
Rust stabilized async functions in traits in 1.75 and the MSRV of this workspace is already 1.88, so `async-trait` no longer earns its place. This drops the dependency and removes all 30 `#[async_trait]` attributes.

## What it buys

- One less proc-macro in the build graph.
- No more `Box<dyn Future>` allocation per call. The state machine paid that on every transition.

## Two things the expansion was hiding

**`StateChangeImpl::handle` needs `where Self: Sized`.** A native async function makes a trait dyn-incompatible, and `State::inner_state` returns `&dyn StateChangeImpl`. The bound keeps `handle` out of the vtable and costs nothing, because `inner_state` only reaches `name`, `is_handling_download` and `is_preemptive_state`.

**`Download::handle` took `mut self` and never mutated it.** The macro moved the binding somewhere `unused_mut` could not see it.

## Notes

- All but one block used `?Send`, which is what a native async function gives on its own. `CommunicationState` used the `Send` variant, but nothing needed its future to be `Send`.
- `async-trait` stays in `Cargo.lock` as an indirect dependency of other crates.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` after `cargo clean` of every workspace crate: no errors, no warnings.
- `cargo test`: 162 pass, 0 fail.