### PR TITLE
test: fs: stop the disk space test racing with the filesystem

### DIFF
--- a/updatehub/src/utils/fs.rs
+++ b/updatehub/src/utils/fs.rs
@@ -457,9 +457,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let available = available_space(dir.path()).unwrap();
 
-        ensure_disk_space(dir.path(), available).unwrap();
+        // `ensure_disk_space` reads the free space itself, and anything else
+        // writing to the same filesystem moves it between the two readings. Stay
+        // away from the boundary on both sides: ask for half of what is there,
+        // then for more than any filesystem can hold.
+        ensure_disk_space(dir.path(), available / 2).unwrap();
         assert!(matches!(
-            ensure_disk_space(dir.path(), available + 1),
+            ensure_disk_space(dir.path(), u64::MAX),
             Err(Error::NotEnoughSpace { .. })
         ));
     }


### PR DESCRIPTION
`a_requirement_beyond_the_available_space_is_rejected` read the free space, then handed the very same number to `ensure_disk_space`, which reads it again:

```rust
let available = available_space(dir.path()).unwrap();   // reading 1
ensure_disk_space(dir.path(), available).unwrap();      // reading 2
```

Any other writer on that filesystem moves the second reading, so the boundary case the test was pinned to falls on the wrong side.

It failed exactly that way in the coverage step of [run 32294740390](https://github.com/UpdateHub/updatehub/actions/runs/32294740390):

```
NotEnoughSpace { available: 80615378944, required: 80615387136 }
```

8 KiB vanished while the two readings ran, because `cargo llvm-cov` has the parallel tests writing `.profraw` files the whole time.

## The fix

Step back from the boundary on both sides. Half of the free space stays available however busy the disk gets, and no filesystem answers with `u64::MAX`, so the rejection no longer depends on what the second reading finds.

This blocks #441, which the same flake failed on with an unrelated diff.

## Verification

- `cargo test --lib utils::fs`: 11 pass, 0 fail.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --locked --all-features --all --tests -- -D clippy::all`: clean.