### PR TITLE
chore: keep test-env out of the default features

### DIFF
--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 repository = "https://github.com/UpdateHub/updatehub.git"
 
 [features]
-default = ["test-env"]
+default = []
 
 # Feature to allow deserialization from v1 Settings
 v1-parsing = ["serde_ini"]
@@ -33,6 +33,20 @@ bench = false
 name = "updatehub-setup-mock-env"
 path = "src/setup_mock_env.rs"
 test = true
+required-features = ["test-env"]
+
+# The integration tests drive the agent against a mock server, so they need the
+# `updatehub::tests` helpers and `mockito`, both of which live behind `test-env`.
+[[test]]
+name = "common"
+required-features = ["test-env"]
+
+[[test]]
+name = "successful_integration_test"
+required-features = ["test-env"]
+
+[[test]]
+name = "failed_integration_test"
 required-features = ["test-env"]
 
 [dependencies]

--- a/updatehub/src/firmware/mod.rs
+++ b/updatehub/src/firmware/mod.rs
@@ -5,7 +5,7 @@
 mod hook;
 pub mod installation_set;
 
-#[cfg(feature = "test-env")]
+#[cfg(any(test, feature = "test-env"))]
 pub mod tests;
 
 use self::hook::{run_hook, run_hooks_from_dir};

--- a/updatehub/src/lib.rs
+++ b/updatehub/src/lib.rs
@@ -17,7 +17,7 @@ mod utils;
 #[cfg(test)]
 mod cloud_mock;
 
-#[cfg(feature = "test-env")]
+#[cfg(any(test, feature = "test-env"))]
 pub mod tests;
 
 #[cfg(test)]


### PR DESCRIPTION
`test-env` gates the `updatehub-setup-mock-env` binary and the `updatehub::tests` helpers the integration tests drive the agent with. It was on by default, so anyone who follows the README and runs `cargo build --release` compiles 18 crates they will never run — `mockito` and its HTTP mock server among them — and pays for them on every build. Nobody should have to remember `--no-default-features` to get the plain agent.

## The change

1. `default = ["test-env"]` becomes `default = []`.
2. `crate::tests` and `crate::firmware::tests` answer to `cfg(test)` as well, so the unit tests keep reaching them with no feature at all.
3. The three integration test targets gain `required-features = ["test-env"]`. They call `updatehub::tests::TestEnvironment` and `mockito`, and cargo builds the library without `cfg(test)` for an integration test, so the feature is the only way in. `cargo test` skips them; `cargo test --all-features` runs them.

`async-ctrlc` and `mockito` stay optional rather than move to `dev-dependencies`, because `src/setup_mock_env.rs` is a binary and cargo gives `dev-dependencies` to tests, examples and benches only.

## Crates the default build no longer pulls

`assert-json-diff`, `async-ctrlc`, `colored`, `ctrlc`, `getrandom`, `lock_api`, `mockito`, `nix`, `parking_lot`, `parking_lot_core`, `ppv-lite86`, `rand`, `rand_chacha`, `rand_core`, `scopeguard`, `serde_urlencoded`, `similar`, `zerocopy`.

The stripped binary loses only 8 KiB (4855400 → 4847208 bytes), because the linker already dropped what the agent never called. The build graph is where this is paid, along with the supply-chain surface of a production build.

## CI

No change needed. Every step already passes `--all-features`, so nothing loses coverage. The `Check build with the default features` step now covers the feature set users really get.

## Verification

| Command | Result |
|---|---|
| `cargo check --locked --all --bins --examples --tests` | clean |
| `cargo check --locked --all --bins --examples --tests --all-features` | clean |
| `cargo clippy --locked --all-features --all --tests -- -D clippy::all` | clean |
| `cargo test` | 145 pass, 0 fail |
| `cargo test --all --all-features --no-fail-fast` | 168 pass, 0 fail |