### PR TITLE
Close 166 of the clippy::pedantic warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,7 +3392,6 @@ dependencies = [
  "futures-util",
  "git-version",
  "insta",
- "lazy_static",
  "logging_content",
  "loopdev-3",
  "mockito",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+# Names of products and specifications, which read as prose and take no
+# backticks in a doc comment.
+doc-valid-idents = ["UpdateHub", "OpenAPI", ".."]

--- a/updatehub-cloud-sdk/src/api.rs
+++ b/updatehub-cloud-sdk/src/api.rs
@@ -73,7 +73,7 @@ impl UpdatePackage {
 
 impl Signature {
     pub fn from_base64_str(bytes: &str) -> crate::Result<Self> {
-        Ok(Signature(openssl::base64::decode_block(bytes)?.to_vec()))
+        Ok(Signature(openssl::base64::decode_block(bytes)?))
     }
 
     pub fn validate(&self, key: &Path, package: &UpdatePackage) -> crate::Result<()> {

--- a/updatehub-cloud-sdk/src/api.rs
+++ b/updatehub-cloud-sdk/src/api.rs
@@ -53,11 +53,20 @@ impl serde::ser::Serialize for MetadataValue<'_> {
 }
 
 impl UpdatePackage {
+    /// Parses the raw metadata of an update package.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `content` is not the JSON document the agent
+    /// expects.
     pub fn parse(content: &[u8]) -> crate::Result<Self> {
         let update_package = serde_json::from_slice(content)?;
         Ok(UpdatePackage { inner: update_package, raw: content.to_vec() })
     }
 
+    /// Returns the SHA-256 sum of the raw metadata, which identifies the
+    /// package.
+    #[must_use]
     pub fn package_uid(&self) -> String {
         openssl::sha::sha256(&self.raw).iter().fold(String::new(), |mut output, c| {
             let _ = write!(output, "{c:02x}");
@@ -66,16 +75,30 @@ impl UpdatePackage {
         })
     }
 
+    /// Returns the version the package declares.
+    #[must_use]
     pub fn version(&self) -> &str {
         &self.inner.version
     }
 }
 
 impl Signature {
+    /// Decodes a signature from its base64 form.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `bytes` is not valid base64.
     pub fn from_base64_str(bytes: &str) -> crate::Result<Self> {
         Ok(Signature(openssl::base64::decode_block(bytes)?))
     }
 
+    /// Checks the signature of `package` against the public key stored at
+    /// `key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the key does not load, when the check itself
+    /// fails, or when the signature does not match the package.
     pub fn validate(&self, key: &Path, package: &UpdatePackage) -> crate::Result<()> {
         use openssl::{hash::MessageDigest, pkey::PKey, rsa::Rsa, sign::Verifier};
         let key = PKey::from_rsa(Rsa::public_key_from_pem(&fs::read(key)?)?)?;

--- a/updatehub-cloud-sdk/src/client.rs
+++ b/updatehub-cloud-sdk/src/client.rs
@@ -75,7 +75,7 @@ impl<'a> Client<'a> {
             .build()
             .unwrap();
 
-        Self { server, client }
+        Self { client, server }
     }
 
     pub async fn probe(
@@ -96,24 +96,24 @@ impl<'a> Client<'a> {
         match response.status() {
             StatusCode::NOT_FOUND => Ok(api::ProbeResponse::NoUpdate),
             StatusCode::OK => {
-                match response
+                let extra_poll = response
                     .headers()
                     .get("add-extra-poll")
                     .and_then(|extra_poll| extra_poll.to_str().ok())
-                    .and_then(|extra_poll| extra_poll.parse().ok())
-                {
-                    Some(extra_poll) => Ok(api::ProbeResponse::ExtraPoll(extra_poll)),
-                    None => {
-                        let signature = response
-                            .headers()
-                            .get("UH-Signature")
-                            .map(TryInto::try_into)
-                            .transpose()?;
-                        Ok(api::ProbeResponse::Update(
-                            api::UpdatePackage::parse(&response.bytes().await?)?,
-                            signature,
-                        ))
-                    }
+                    .and_then(|extra_poll| extra_poll.parse().ok());
+
+                if let Some(extra_poll) = extra_poll {
+                    Ok(api::ProbeResponse::ExtraPoll(extra_poll))
+                } else {
+                    let signature = response
+                        .headers()
+                        .get("UH-Signature")
+                        .map(TryInto::try_into)
+                        .transpose()?;
+                    Ok(api::ProbeResponse::Update(
+                        api::UpdatePackage::parse(&response.bytes().await?)?,
+                        signature,
+                    ))
                 }
             }
             s => Err(Error::InvalidStatusResponse(s)),
@@ -162,8 +162,6 @@ impl<'a> Client<'a> {
         error_message: Option<String>,
         current_log: Option<String>,
     ) -> Result<()> {
-        validate_url(self.server)?;
-
         #[derive(serde::Serialize)]
         #[serde(rename_all = "kebab-case")]
         struct Payload<'a> {
@@ -179,6 +177,8 @@ impl<'a> Client<'a> {
             #[serde(skip_serializing_if = "Option::is_none")]
             current_log: Option<String>,
         }
+
+        validate_url(self.server)?;
 
         let payload =
             Payload { state, firmware, package_uid, previous_state, error_message, current_log };

--- a/updatehub-cloud-sdk/src/client.rs
+++ b/updatehub-cloud-sdk/src/client.rs
@@ -16,6 +16,13 @@ pub struct Client<'a> {
     server: &'a str,
 }
 
+/// Downloads the content of `url` into `handle`.
+///
+/// # Errors
+///
+/// Returns an error when `url` does not parse, when the request fails, when the
+/// server answers with a status other than success, or when the write to
+/// `handle` fails.
 pub async fn get<W>(url: &str, handle: &mut W) -> Result<()>
 where
     W: io::AsyncWrite + Unpin,
@@ -60,6 +67,13 @@ where
 }
 
 impl<'a> Client<'a> {
+    /// Constructs a client that talks to the server at `server`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the platform gives no TLS backend to build the HTTP client
+    /// with.
+    #[must_use]
     pub fn new(server: &'a str) -> Self {
         let mut headers = header::HeaderMap::new();
         headers.insert(header::USER_AGENT, header::HeaderValue::from_static("updatehub/2.0 Linux"));
@@ -78,6 +92,13 @@ impl<'a> Client<'a> {
         Self { client, server }
     }
 
+    /// Asks the server whether an update is available for this device.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the server address does not parse, when the
+    /// request fails, when the server answers with an unexpected status, or
+    /// when the update metadata does not parse.
     pub async fn probe(
         &self,
         num_retries: usize,
@@ -120,6 +141,16 @@ impl<'a> Client<'a> {
         }
     }
 
+    /// Downloads one object of an update package into `download_dir`.
+    ///
+    /// Downloads that stopped part way continue from the number of bytes
+    /// already on disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the server address does not parse, when the
+    /// request fails, when the server answers with a status other than
+    /// success, or when the write to disk fails.
     pub async fn download_object(
         &self,
         product_uid: &str,
@@ -153,6 +184,12 @@ impl<'a> Client<'a> {
         save_body_to(request.send().await?, &mut file).await
     }
 
+    /// Reports the current state of the device to the server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the server address does not parse or when the
+    /// request fails.
     pub async fn report(
         &self,
         state: &str,

--- a/updatehub-cloud-sdk/src/client.rs
+++ b/updatehub-cloud-sdk/src/client.rs
@@ -35,21 +35,22 @@ where
         return Err(Error::InvalidStatusResponse(resp.status()));
     }
 
-    let mut written: f32 = 0.;
+    let mut written: u64 = 0;
     let mut threshold = 10;
     let length = match resp.headers().get(header::CONTENT_LENGTH) {
-        Some(v) => usize::from_str(v.to_str()?)?,
+        Some(v) => u64::from_str(v.to_str()?)?,
         None => 0,
     };
 
     while let Some(chunk) = resp.chunk().await? {
-        let read = chunk.len();
+        let read = chunk.len() as u64;
         handle.write_all(&chunk).await?;
         if length > 0 {
-            written += read as f32 / (length as f32 / 100.);
-            if written as usize >= threshold {
+            written += read;
+            let percent = written * 100 / length;
+            if percent >= threshold {
                 threshold += 20;
-                debug!("{}% of the file has been downloaded", std::cmp::min(written as usize, 100));
+                debug!("{}% of the file has been downloaded", std::cmp::min(percent, 100));
             }
         }
     }

--- a/updatehub-package-schema/src/definitions/chunk_size.rs
+++ b/updatehub-package-schema/src/definitions/chunk_size.rs
@@ -46,7 +46,7 @@ mod test {
             serde_json::from_value::<Payload>(json!({ "chunk_size": 313 })).ok(),
             Some(Payload { chunk_size: ChunkSize(313) })
         );
-        assert!(serde_json::from_value::<Payload>(json!({ "chunk_size": 0 })).is_err())
+        assert!(serde_json::from_value::<Payload>(json!({ "chunk_size": 0 })).is_err());
     }
 
     #[test]

--- a/updatehub-package-schema/src/definitions/install_if_different.rs
+++ b/updatehub-package-schema/src/definitions/install_if_different.rs
@@ -91,6 +91,6 @@ mod test {
                 "pattern": "linux-kernel"
             }))
             .unwrap()
-        )
+        );
     }
 }

--- a/updatehub-sdk/src/api/info/firmware.rs
+++ b/updatehub-sdk/src/api/info/firmware.rs
@@ -51,10 +51,12 @@ impl MetadataValue {
         self.0.keys()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.len() == 0
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/updatehub-sdk/src/client.rs
+++ b/updatehub-sdk/src/client.rs
@@ -24,6 +24,7 @@ impl Default for Client {
 
 impl Client {
     /// Constructs a new `Client`.
+    #[must_use]
     pub fn new(server_address: &str) -> Self {
         Client { server_address: format!("http://{server_address}"), ..Self::default() }
     }

--- a/updatehub-sdk/src/lib.rs
+++ b/updatehub-sdk/src/lib.rs
@@ -7,12 +7,12 @@
 //! When running an agent instance, the API provides some methods
 //! for communicating with UpdateHub:
 //!
-//! - [abort_download](Client::abort_download)
+//! - [`abort_download`](Client::abort_download)
 //! - [info](Client::info)
-//! - [local_install](Client::local_install)
+//! - [`local_install`](Client::local_install)
 //! - [log](Client::log)
 //! - [probe](Client::probe)
-//! - [remote_install](Client::remote_install)
+//! - [`remote_install`](Client::remote_install)
 
 pub mod api;
 mod client;

--- a/updatehub-sdk/src/listener.rs
+++ b/updatehub-sdk/src/listener.rs
@@ -103,7 +103,7 @@ impl StateChange {
         F: Fn(Handler) -> Fut + 'static,
         Fut: Future<Output = Result<()>> + 'static,
     {
-        self.callbacks.entry(state).or_default().push(Box::new(move |d| Box::pin(f(d))))
+        self.callbacks.entry(state).or_default().push(Box::new(move |d| Box::pin(f(d))));
     }
 
     /// Start the agent to listen for messages on the socket.

--- a/updatehub-sdk/src/listener.rs
+++ b/updatehub-sdk/src/listener.rs
@@ -65,11 +65,21 @@ pub struct Handler {
 
 impl Handler {
     /// Cancels the current action on the agent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the write to the agent socket fails.
     pub async fn cancel(&mut self) -> Result<()> {
         self.stream.lock().await.write_all(b"cancel").await.map_err(Error::Io)
     }
 
     /// Tell the agent to proceed with the transition.
+    ///
+    /// # Errors
+    ///
+    /// Never returns an error. The agent proceeds when it receives no message
+    /// at all, so this function only keeps the shape of the other handler
+    /// commands.
     pub async fn proceed(&self) -> Result<()> {
         // No message need to be sent to the connection in order to the
         // agent to proceed handling the current state.
@@ -80,6 +90,7 @@ impl Handler {
 impl StateChange {
     /// Creates a new `StateChange` struct.
     #[inline]
+    #[must_use]
     pub fn new() -> Self {
         StateChange::default()
     }
@@ -107,6 +118,11 @@ impl StateChange {
     }
 
     /// Start the agent to listen for messages on the socket.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the socket cannot be created or read, or when a
+    /// registered callback returns an error.
     pub async fn listen(&self) -> Result<()> {
         let sdk_trigger = Path::new(SDK_TRIGGER_FILENAME);
         if !sdk_trigger.exists() {

--- a/updatehub-sdk/tests/openapi_integration.rs
+++ b/updatehub-sdk/tests/openapi_integration.rs
@@ -43,8 +43,7 @@ async fn probe_default() {
     let client = sdk::Client::new(&addr);
     let response = client.probe(None).await;
     match dbg!(response) {
-        Ok(_) => {}
-        Err(sdk::Error::AgentIsBusy(_)) => {}
+        Ok(_) | Err(sdk::Error::AgentIsBusy(_)) => {}
         Err(e) => panic!("Unexpected Error response: {e}"),
     }
 }
@@ -55,8 +54,7 @@ async fn probe_custom() {
     let client = sdk::Client::new(&addr);
     let response = client.probe(Some(String::from("http://foo.bar"))).await;
     match dbg!(response) {
-        Ok(_) => {}
-        Err(sdk::Error::AgentIsBusy(_)) => {}
+        Ok(_) | Err(sdk::Error::AgentIsBusy(_)) => {}
         Err(e) => panic!("Unexpected Error response: {e}"),
     }
 }
@@ -69,8 +67,7 @@ async fn local_install() {
     let response = client.local_install(file.path()).await;
 
     match dbg!(response) {
-        Ok(_) => {}
-        Err(sdk::Error::AgentIsBusy(_)) => {}
+        Ok(_) | Err(sdk::Error::AgentIsBusy(_)) => {}
         Err(e) => panic!("Unexpected Error response: {e}"),
     }
 }
@@ -81,8 +78,7 @@ async fn remote_install() {
     let client = sdk::Client::new(&addr);
     let response = client.remote_install("http://foo.bar").await;
     match dbg!(response) {
-        Ok(_) => {}
-        Err(sdk::Error::AgentIsBusy(_)) => {}
+        Ok(_) | Err(sdk::Error::AgentIsBusy(_)) => {}
         Err(e) => panic!("Unexpected Error response: {e}"),
     }
 }
@@ -93,8 +89,7 @@ async fn abort_download() {
     let client = sdk::Client::new(&addr);
     let response = client.abort_download().await;
     match dbg!(response) {
-        Ok(_) => {}
-        Err(sdk::Error::AbortDownloadRefused(_)) => {}
+        Ok(_) | Err(sdk::Error::AbortDownloadRefused(_)) => {}
         Err(e) => panic!("Unexpected Error response: {e}"),
     }
 }

--- a/updatehub/Cargo.toml
+++ b/updatehub/Cargo.toml
@@ -71,7 +71,6 @@ derive_more = { version = "2", default-features = false, features = [
 easy_process = "0.2"
 find-binary-version = "0.5"
 futures-util = { version = "0.3", default-features = false }
-lazy_static = "1"
 logging_content = "0.1"
 mockito = { version = "1", optional = true }
 ms-converter = "1"

--- a/updatehub/src/build_info.rs
+++ b/updatehub/src/build_info.rs
@@ -14,6 +14,7 @@
 ///
 /// println!("Running version: {}", updatehub::version());
 /// ```
+#[must_use]
 pub fn version() -> &'static str {
     env!("VERSION")
 }

--- a/updatehub/src/cloud_mock.rs
+++ b/updatehub/src/cloud_mock.rs
@@ -64,7 +64,7 @@ impl<'a> Client<'a> {
         object: &str,
     ) -> Result<()> {
         if let Some(data) = OBJECT_DATA.with(|conf| conf.borrow_mut().take()) {
-            tokio::fs::write(download_dir.join(object), data).await?
+            tokio::fs::write(download_dir.join(object), data).await?;
         }
 
         Ok(())

--- a/updatehub/src/firmware/hook.rs
+++ b/updatehub/src/firmware/hook.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 
 pub(crate) fn run_hook(path: &Path) -> Result<String> {
     if !path.exists() {
-        return Ok("".into());
+        return Ok(String::new());
     }
 
     run_script(path.to_str().expect("invalid path for hook"))
@@ -35,7 +35,7 @@ pub(crate) fn run_script(cmd: &str) -> Result<String> {
         Err(easy_process::Error::Failure(status, output)) => {
             error!("Script {} failed to run: {}", cmd, status);
             if !output.stderr.is_empty() {
-                output.stderr.lines().for_each(|err| error!("{} (stderr): {}", cmd, err))
+                output.stderr.lines().for_each(|err| error!("{} (stderr): {}", cmd, err));
             }
             Err(easy_process::Error::Failure(status, output).into())
         }

--- a/updatehub/src/firmware/mod.rs
+++ b/updatehub/src/firmware/mod.rs
@@ -57,6 +57,12 @@ pub(crate) enum Transition {
 pub struct Metadata(pub api::Metadata);
 
 impl Metadata {
+    /// Collects the firmware metadata by running the hooks stored under `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a hook is missing, when a hook fails, or when the
+    /// output of a hook does not have the expected form.
     pub fn from_path(path: &Path) -> Result<Self> {
         let product_uid_hook = path.join(PRODUCT_UID_HOOK);
         let version_hook = path.join(VERSION_HOOK);

--- a/updatehub/src/http_api.rs
+++ b/updatehub/src/http_api.rs
@@ -13,7 +13,7 @@ pub(crate) struct Api();
 
 impl Api {
     pub(crate) async fn serve(addr: machine::Addr, socket: std::net::SocketAddr) {
-        warp::serve(Api::filter(addr)).run(socket).await
+        warp::serve(Api::filter(addr)).run(socket).await;
     }
 
     fn filter(addr: machine::Addr) -> warp::filters::BoxedFilter<(impl warp::Reply,)> {

--- a/updatehub/src/logger.rs
+++ b/updatehub/src/logger.rs
@@ -59,6 +59,9 @@ pub fn record_out_of_scope<R>(f: impl FnOnce() -> R) -> R {
     result
 }
 
+/// Returns everything the memory drain holds for the current scope of
+/// operation.
+#[must_use]
 pub fn get_memory_log() -> String {
     buffer_lock().to_string()
 }

--- a/updatehub/src/logger.rs
+++ b/updatehub/src/logger.rs
@@ -31,15 +31,15 @@ pub fn buffer() -> Arc<Mutex<MemDrain>> {
 /// The buffered drain, recovering the lock if a thread panicked while holding
 /// it: being unable to log must not bring the agent down.
 fn buffer_lock() -> MutexGuard<'static, MemDrain> {
-    BUFFER.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    BUFFER.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 pub fn start_memory_logging() {
-    buffer_lock().start_logging()
+    buffer_lock().start_logging();
 }
 
 pub fn stop_memory_logging() {
-    buffer_lock().stop_logging()
+    buffer_lock().stop_logging();
 }
 
 /// Record what `f` logs even while memory logging is stopped.

--- a/updatehub/src/logger.rs
+++ b/updatehub/src/logger.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::mem_drain::MemDrain;
-use lazy_static::lazy_static;
 use slog::{Drain, Logger, o};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
-lazy_static! {
-    static ref BUFFER: Arc<Mutex<MemDrain>> = Arc::new(Mutex::new(MemDrain::default()));
-}
+static BUFFER: LazyLock<Arc<Mutex<MemDrain>>> =
+    LazyLock::new(|| Arc::new(Mutex::new(MemDrain::default())));
 
 pub fn init(level: slog::Level) -> slog_scope::GlobalLoggerGuard {
     let buffer_drain = buffer().filter_level(level).fuse();

--- a/updatehub/src/main.rs
+++ b/updatehub/src/main.rs
@@ -97,7 +97,7 @@ struct DaemonOptions {
 
 fn verbosity_level(value: &str) -> Result<slog::Level, String> {
     use std::str::FromStr;
-    slog::Level::from_str(value).map_err(|_| format!("failed to parse verbosity level: {value}"))
+    slog::Level::from_str(value).map_err(|()| format!("failed to parse verbosity level: {value}"))
 }
 
 async fn daemon_main(cmd: DaemonOptions) -> updatehub::Result<()> {
@@ -157,10 +157,10 @@ async fn client_main(client_options: ClientOptions) -> updatehub::Result<()> {
             } else {
                 match response {
                     sdk::api::probe::Response::Updating => {
-                        println!("Update available. The update is running in background.")
+                        println!("Update available. The update is running in background.");
                     }
                     sdk::api::probe::Response::NoUpdate => {
-                        println!("There are no updates available.")
+                        println!("There are no updates available.");
                     }
                     sdk::api::probe::Response::TryAgain(t) => {
                         println!("Server replied asking us to try again in {t} seconds");

--- a/updatehub/src/mem_drain.rs
+++ b/updatehub/src/mem_drain.rs
@@ -128,11 +128,11 @@ impl MemDrain {
     /// The recorded entries, recovering the lock if a thread panicked while
     /// holding it: being unable to log must not bring the agent down.
     fn records(&self) -> RwLockReadGuard<'_, Records> {
-        self.records.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+        self.records.read().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     fn records_mut(&self) -> RwLockWriteGuard<'_, Records> {
-        self.records.write().unwrap_or_else(|poisoned| poisoned.into_inner())
+        self.records.write().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     /// Start recording a new operation, discarding what the previous one left.

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -264,13 +264,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn copy_compressed_file() {
         exec_test_with_copy(|obj| obj.compressed = true, None, true).await.unwrap();
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn copy_over_formated_partion() {
         exec_test_with_copy(|obj| obj.target_format.should_format = true, None, false)
             .await
@@ -278,7 +278,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn copy_over_existing_file() {
         exec_test_with_copy(
             |_| (),
@@ -294,7 +294,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn copy_change_uid() {
         exec_test_with_copy(
             |obj| {
@@ -309,7 +309,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn copy_change_gid() {
         exec_test_with_copy(
             |obj| {
@@ -328,7 +328,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn copy_change_mode() {
         exec_test_with_copy(
             |obj| obj.target_permissions.target_mode = Some(0o444),

--- a/updatehub/src/object/installer/copy.rs
+++ b/updatehub/src/object/installer/copy.rs
@@ -45,7 +45,7 @@ impl Installer for objects::Copy {
         let device = self.target_type.get_target().log_error_msg("failed to get target device")?;
         let filesystem = self.filesystem;
         let mount_options = &self.mount_options;
-        let format_options = &self.target_format.format_options;
+        let format_options = self.target_format.format_options.as_deref();
         let chunk_size = definitions::ChunkSize::default().0;
         let sha256sum = self.sha256sum();
         let target_path = self.target_path.strip_prefix("/").unwrap_or(&self.target_path);
@@ -56,7 +56,7 @@ impl Installer for objects::Copy {
             let file_path = mount_guard.mount_point().join(target_path);
             let should_skip_install = file_path.exists()
                 && super::should_skip_install(
-                    &self.install_if_different,
+                    self.install_if_different.as_ref(),
                     &self.sha256sum,
                     async move { Ok(fs::File::open(file_path).await?) },
                 )
@@ -113,8 +113,8 @@ impl Installer for objects::Copy {
 
         utils::fs::chown(
             &dest,
-            &self.target_permissions.target_uid,
-            &self.target_permissions.target_gid,
+            self.target_permissions.target_uid.as_ref(),
+            self.target_permissions.target_gid.as_ref(),
         )
         .log_error_msg("failed to update ownership")?;
 
@@ -164,7 +164,7 @@ mod tests {
         };
 
         // Format the faked device
-        utils::fs::format(&device, definitions::Filesystem::Ext4, &None)?;
+        utils::fs::format(&device, definitions::Filesystem::Ext4, None)?;
 
         // Generate the source file
         let download_dir = tempfile::tempdir()?;
@@ -193,12 +193,12 @@ mod tests {
                 utils::fs::chmod(&file, mode)?;
             }
 
-            utils::fs::chown(&file, &perm.target_uid, &perm.target_gid)?;
+            utils::fs::chown(&file, perm.target_uid.as_ref(), perm.target_gid.as_ref())?;
         }
 
         // Generate base copy object
         let mut obj = objects::Copy {
-            filename: "".to_string(),
+            filename: String::new(),
             filesystem: definitions::Filesystem::Ext4,
             size: FILE_SIZE as u64,
             sha256sum: source.path().to_string_lossy().to_string(),
@@ -245,17 +245,17 @@ mod tests {
             let metadata = dest.metadata()?;
             if let Some(mode) = obj.target_permissions.target_mode {
                 assert_eq!(mode, metadata.mode() % 0o1000);
-            };
+            }
 
             if let Some(uid) = obj.target_permissions.target_uid {
                 let uid = uid.as_u32();
                 assert_eq!(uid, metadata.uid());
-            };
+            }
 
             if let Some(gid) = obj.target_permissions.target_gid {
                 let gid = gid.as_u32();
                 assert_eq!(gid, metadata.gid());
-            };
+            }
         }
 
         loopdev.detach()?;
@@ -299,7 +299,7 @@ mod tests {
         exec_test_with_copy(
             |obj| {
                 obj.target_permissions.target_uid =
-                    Some(definitions::target_permissions::Uid::Number(0))
+                    Some(definitions::target_permissions::Uid::Number(0));
             },
             None,
             false,
@@ -314,7 +314,7 @@ mod tests {
         exec_test_with_copy(
             |obj| {
                 obj.target_permissions.target_gid =
-                    Some(definitions::target_permissions::Gid::Number(0))
+                    Some(definitions::target_permissions::Gid::Number(0));
             },
             Some(definitions::TargetPermissions {
                 target_mode: Some(0o666),

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -125,7 +125,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to load the MTD simulator modules"]
     async fn install_nor() {
         let _mtd_lock = SERIALIZE.lock();
         let mtd = FakeMtd::new(&["system0"], MtdKind::Nor).unwrap();

--- a/updatehub/src/object/installer/flash.rs
+++ b/updatehub/src/object/installer/flash.rs
@@ -30,7 +30,9 @@ impl Installer for objects::Flash {
                 )?;
                 Ok(())
             }
-            _ => Err(Error::InvalidTargetType(self.target.clone())),
+            definitions::TargetType::UBIVolume(_) => {
+                Err(Error::InvalidTargetType(self.target.clone()))
+            }
         }
     }
 
@@ -40,7 +42,7 @@ impl Installer for objects::Flash {
         let target = self.target.get_target()?;
         let source = context.download_dir.join(self.sha256sum());
 
-        if super::should_skip_install(&self.install_if_different, &self.sha256sum, async {
+        if super::should_skip_install(self.install_if_different.as_ref(), &self.sha256sum, async {
             tokio::fs::File::open(&target).await.map_err(Error::from)
         })
         .await?

--- a/updatehub/src/object/installer/imxkobs.rs
+++ b/updatehub/src/object/installer/imxkobs.rs
@@ -36,15 +36,18 @@ impl Installer for objects::Imxkobs {
     async fn install(&self, context: &Context) -> Result<()> {
         info!("'imxkobs' handler Install {} ({})", self.filename, self.sha256sum);
 
-        let should_skip_install =
-            super::should_skip_install(&self.install_if_different, &self.sha256sum, async {
+        let should_skip_install = super::should_skip_install(
+            self.install_if_different.as_ref(),
+            &self.sha256sum,
+            async {
                 let path = chip_0_path(self);
                 let f = path.file_name().ok_or(Error::InvalidPath)?;
                 let mut file_name = f.to_os_string();
                 file_name.push("ro");
                 tokio::fs::File::open(path.with_file_name(file_name)).await.map_err(Error::from)
-            })
-            .await?;
+            },
+        )
+        .await?;
         if should_skip_install {
             return Ok(());
         }
@@ -52,8 +55,8 @@ impl Installer for objects::Imxkobs {
         let mut cmd = String::from("kobs-ng init ");
 
         if self.padding_1k {
-            cmd += "-x "
-        };
+            cmd += "-x ";
+        }
 
         cmd += context
             .download_dir

--- a/updatehub/src/object/installer/mod.rs
+++ b/updatehub/src/object/installer/mod.rs
@@ -76,7 +76,8 @@ async fn check_if_different<R: AsyncRead + AsyncSeek + Unpin>(
         }
         definitions::InstallIfDifferent::CustomPattern { version, pattern } => {
             handle.seek(io::SeekFrom::Start(pattern.seek)).await?;
-            let mut src = BufReader::with_capacity(pattern.buffer_size as usize, handle);
+            let buffer_size = usize::try_from(pattern.buffer_size).unwrap_or(usize::MAX);
+            let mut src = BufReader::with_capacity(buffer_size, handle);
             if let Some(ref cur_version) =
                 fbv::version_with_pattern(&mut src, &pattern.regexp).await
             {

--- a/updatehub/src/object/installer/mod.rs
+++ b/updatehub/src/object/installer/mod.rs
@@ -91,7 +91,7 @@ async fn check_if_different<R: AsyncRead + AsyncSeek + Unpin>(
 }
 
 async fn should_skip_install<F, R>(
-    rule: &Option<definitions::InstallIfDifferent>,
+    rule: Option<&definitions::InstallIfDifferent>,
     sha256sum: &str,
     handler: F,
 ) -> Result<bool>

--- a/updatehub/src/object/installer/mod.rs
+++ b/updatehub/src/object/installer/mod.rs
@@ -130,20 +130,17 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use lazy_static::lazy_static;
     use std::{
         fs,
         io::Write,
         os::unix::fs::PermissionsExt,
         path::{Path, PathBuf},
-        sync::{Arc, Mutex},
+        sync::{Arc, LazyLock, Mutex},
     };
     use tempfile::TempDir;
 
     // Used to serialize access to Loop devices across tests
-    lazy_static! {
-        pub static ref SERIALIZE: Arc<Mutex<()>> = Arc::new(Mutex::default());
-    }
+    pub static SERIALIZE: LazyLock<Arc<Mutex<()>>> = LazyLock::new(|| Arc::new(Mutex::default()));
 
     fn create_echo_bin(bin: &Path, output: &Path) -> std::io::Result<()> {
         let mut file = std::fs::File::create(bin)?;

--- a/updatehub/src/object/installer/raw.rs
+++ b/updatehub/src/object/installer/raw.rs
@@ -38,9 +38,8 @@ impl Installer for objects::Raw {
     async fn install(&self, context: &Context) -> Result<()> {
         info!("'raw' handler Install {} ({})", self.filename, self.sha256sum);
 
-        let device = match self.target_type {
-            definitions::TargetType::Device(ref p) => p,
-            _ => unreachable!("device should be secured by check_requirements"),
+        let definitions::TargetType::Device(ref device) = self.target_type else {
+            unreachable!("device should be secured by check_requirements")
         };
         let source = context.download_dir.join(self.sha256sum());
         let chunk_size = self.chunk_size.0;
@@ -49,8 +48,10 @@ impl Installer for objects::Raw {
         let truncate = self.truncate.0;
         let count = self.count.clone();
 
-        let should_skip_install =
-            super::should_skip_install(&self.install_if_different, &self.sha256sum, async {
+        let should_skip_install = super::should_skip_install(
+            self.install_if_different.as_ref(),
+            &self.sha256sum,
+            async {
                 trait AsyncReadSeek: AsyncRead + AsyncSeek + Unpin {}
                 impl<R: AsyncRead + AsyncSeek + Unpin> AsyncReadSeek for R {}
 
@@ -65,8 +66,9 @@ impl Installer for objects::Raw {
                     }
                 };
                 Ok(h)
-            })
-            .await?;
+            },
+        )
+        .await?;
         if should_skip_install {
             return Ok(());
         }
@@ -155,7 +157,7 @@ mod tests {
 
         Ok((
             objects::Raw {
-                filename: "".to_string(),
+                filename: String::new(),
                 size,
                 sha256sum: source.path().to_string_lossy().to_string(),
                 target_type: definitions::TargetType::Device(dest.path().into()),

--- a/updatehub/src/object/installer/raw.rs
+++ b/updatehub/src/object/installer/raw.rs
@@ -60,7 +60,8 @@ impl Installer for objects::Raw {
                 let h: Box<dyn AsyncReadSeek> = match &count {
                     definitions::Count::All => Box::new(h),
                     definitions::Count::Limited(n) => {
-                        Box::new(h.take_with_seek((*n as usize * chunk_size) as u64))
+                        let count = u64::try_from(*n).unwrap_or(0);
+                        Box::new(h.take_with_seek(count * chunk_size as u64))
                     }
                 };
                 Ok(h)
@@ -79,7 +80,8 @@ impl Installer for objects::Raw {
             match count {
                 definitions::Count::All => Box::new(input),
                 definitions::Count::Limited(n) => {
-                    Box::new(input.take((n as usize * chunk_size) as u64))
+                    let count = u64::try_from(n).unwrap_or(0);
+                    Box::new(input.take(count * chunk_size as u64))
                 }
             }
         };
@@ -135,7 +137,8 @@ mod tests {
         let download_dir = tempdir()?;
 
         let mut source = NamedTempFile::new_in(download_dir.path())?;
-        let original_data = std::iter::repeat_n(ORIGINAL_BYTE, size as usize).collect::<Vec<_>>();
+        let data_len = usize::try_from(size).unwrap();
+        let original_data = std::iter::repeat_n(ORIGINAL_BYTE, data_len).collect::<Vec<_>>();
         let data = if compressed {
             let mut e = GzEncoder::new(Vec::new(), Compression::default());
             e.write_all(&original_data).unwrap();
@@ -147,7 +150,7 @@ mod tests {
         source.seek(SeekFrom::Start(0))?;
 
         let mut dest = NamedTempFile::new_in(download_dir.path())?;
-        dest.write_all(&std::iter::repeat_n(DEFAULT_BYTE, size as usize).collect::<Vec<_>>())?;
+        dest.write_all(&std::iter::repeat_n(DEFAULT_BYTE, data_len).collect::<Vec<_>>())?;
         dest.seek(SeekFrom::Start(0))?;
 
         Ok((
@@ -200,7 +203,7 @@ mod tests {
         seek: u64,
         count: definitions::Count,
     ) -> io::Result<()> {
-        let skip = skip as usize * chunk_size;
+        let skip = usize::try_from(skip).unwrap() * chunk_size;
         let file = fs::File::open(file).await?;
         let mut f1 = io::BufReader::with_capacity(chunk_size, &data[skip..]);
         let mut f2 = io::BufReader::with_capacity(chunk_size, file);

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -41,7 +41,7 @@ impl Installer for objects::Tarball {
         let device = self.target.get_target().log_error_msg("failed to get target device")?;
         let filesystem = self.filesystem;
         let mount_options = &self.mount_options;
-        let format_options = &self.target_format.format_options;
+        let format_options = self.target_format.format_options.as_deref();
         let sha256sum = self.sha256sum();
         let target_path = self.target_path.strip_prefix("/").unwrap_or(&self.target_path);
         let source = context.download_dir.join(sha256sum);
@@ -100,11 +100,11 @@ mod tests {
         };
 
         // Format the faked device
-        utils::fs::format(&device, definitions::Filesystem::Ext4, &None)?;
+        utils::fs::format(&device, definitions::Filesystem::Ext4, None)?;
 
         // Generate base copy object
         let mut obj = objects::Tarball {
-            filename: "".to_string(),
+            filename: String::new(),
             filesystem: definitions::Filesystem::Ext4,
             size: CONTENT_SIZE as u64,
             sha256sum: "tree.tar".to_string(),

--- a/updatehub/src/object/installer/tarball.rs
+++ b/updatehub/src/object/installer/tarball.rs
@@ -153,13 +153,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn install_over_formated_partion() {
         exec_test_with_tarball(|obj| obj.target_format.should_format = true).await.unwrap();
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     async fn install_over_unformated_partion() {
         exec_test_with_tarball(|obj| obj.target_path = PathBuf::from("/existing_dir"))
             .await

--- a/updatehub/src/object/installer/ubifs.rs
+++ b/updatehub/src/object/installer/ubifs.rs
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
+    #[ignore = "needs root to load the MTD simulator modules"]
     async fn install() {
         let _mtd_lock = SERIALIZE.lock();
         let _ubi = FakeUbi::new(&["home"], MtdKind::Nor).unwrap();

--- a/updatehub/src/runtime_settings.rs
+++ b/updatehub/src/runtime_settings.rs
@@ -63,6 +63,19 @@ impl Default for RuntimeSettings {
 }
 
 impl RuntimeSettings {
+    /// Loads the runtime settings stored at `path`, or the default ones when
+    /// the file is absent.
+    ///
+    /// A file that fails to parse is renamed with a `.old` suffix, and the
+    /// default settings take its place.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file exists but cannot be read.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `path` names no file, or when that name is not valid UTF-8.
     pub fn load(path: &Path) -> Result<Self> {
         let mut this = if path.exists() {
             debug!("loading runtime settings from {:?}", path);

--- a/updatehub/src/settings.rs
+++ b/updatehub/src/settings.rs
@@ -172,7 +172,7 @@ fn v1_parse(content: &str, toml_err: toml::de::Error) -> Result<api::Settings> {
                     "dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs",
                 ]
                 .iter()
-                .map(|i| i.to_string())
+                .map(|i| (*i).to_string())
                 .collect(),
             }
         }
@@ -340,7 +340,7 @@ metadata="/usr/share/updatehub"
                     "dry-run", "copy", "flash", "imxkobs", "raw", "tarball", "ubifs",
                 ]
                 .iter()
-                .map(|i| i.to_string())
+                .map(|i| (*i).to_string())
                 .collect(),
             },
             network: api::Network {
@@ -381,7 +381,10 @@ ListenSocket=localhost:8313
             },
             update: api::Update {
                 download_dir: "/tmp/download".into(),
-                supported_install_modes: ["mode1", "mode2"].iter().map(|i| i.to_string()).collect(),
+                supported_install_modes: ["mode1", "mode2"]
+                    .iter()
+                    .map(|i| (*i).to_string())
+                    .collect(),
             },
             network: api::Network {
                 server_address: "http://localhost".to_string(),

--- a/updatehub/src/settings.rs
+++ b/updatehub/src/settings.rs
@@ -59,6 +59,11 @@ impl Settings {
     /// Loads the settings from the filesystem. If
     /// `/etc/updatehub.conf` does not exists, it uses the default
     /// settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be read, when it does not parse,
+    /// or when a value it holds fails validation.
     pub fn load(path: &Path) -> Result<Self> {
         if path.exists() {
             debug!("loading system settings from {:?}", path);

--- a/updatehub/src/states/direct_download.rs
+++ b/updatehub/src/states/direct_download.rs
@@ -28,7 +28,7 @@ impl StateChangeImpl for DirectDownload {
 
     async fn handle(self, context: &mut Context) -> Result<(State, machine::StepTransition)> {
         info!("fetching update package directly from url: {:?}", self.url);
-        use std::ops::DerefMut;
+
         let communication_receiver = &context.communication.receiver.clone();
         let context = Mutex::new(context);
 
@@ -48,9 +48,8 @@ impl StateChangeImpl for DirectDownload {
 
         let message_handle_future = async {
             while let Ok((msg, responder)) = communication_receiver.recv().await {
-                if let Some(new_state) = self
-                    .handle_communication(msg, responder, context.lock().await.deref_mut())
-                    .await
+                if let Some(new_state) =
+                    self.handle_communication(msg, responder, *context.lock().await).await
                 {
                     return Ok(new_state);
                 }

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -28,7 +28,7 @@ impl Download {
     ) -> Result<()> {
         let installation_set =
             installation_set::inactive().log_error_msg("unable to get current installation set")?;
-        let download_dir = context.lock().await.settings.update.download_dir.to_owned();
+        let download_dir = context.lock().await.settings.update.download_dir.clone();
 
         update_package
             .clear_unrelated_files(&download_dir, installation_set, &context.lock().await.settings)

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -58,11 +58,15 @@ impl Download {
                             Some((filename, sha256sum))
                         }
 
-                        (filename, sha256sum, Ok(object::info::Status::Missing))
-                        | (filename, sha256sum, Ok(object::info::Status::Incomplete))
-                        | (filename, sha256sum, Ok(object::info::Status::Corrupted)) => {
-                            Some((filename, sha256sum))
-                        }
+                        (
+                            filename,
+                            sha256sum,
+                            Ok(
+                                object::info::Status::Missing
+                                | object::info::Status::Incomplete
+                                | object::info::Status::Corrupted,
+                            ),
+                        ) => Some((filename, sha256sum)),
 
                         (_, _, Ok(object::info::Status::Ready)) => None,
                     }
@@ -125,7 +129,6 @@ impl StateChangeImpl for Download {
     }
 
     async fn handle(self, context: &mut Context) -> Result<(State, machine::StepTransition)> {
-        use std::ops::DerefMut;
         let communication_receiver = &context.communication.receiver.clone();
         let context = Mutex::new(context);
 
@@ -137,9 +140,8 @@ impl StateChangeImpl for Download {
 
         let message_handle_future = async {
             while let Ok((msg, responder)) = communication_receiver.recv().await {
-                if let Some(new_state) = self
-                    .handle_communication(msg, responder, context.lock().await.deref_mut())
-                    .await
+                if let Some(new_state) =
+                    self.handle_communication(msg, responder, *context.lock().await).await
                 {
                     return Ok(Some(new_state));
                 }
@@ -231,12 +233,12 @@ mod test {
     #[tokio::test]
     #[ignore]
     async fn download_small_object() {
-        test_object_download(16).await
+        test_object_download(16).await;
     }
 
     #[tokio::test]
     #[ignore]
     async fn download_large_object() {
-        test_object_download(100_000_000).await
+        test_object_download(100_000_000).await;
     }
 }

--- a/updatehub/src/states/download.rs
+++ b/updatehub/src/states/download.rs
@@ -231,13 +231,11 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn download_small_object() {
         test_object_download(16).await;
     }
 
     #[tokio::test]
-    #[ignore]
     async fn download_large_object() {
         test_object_download(100_000_000).await;
     }

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -165,7 +165,7 @@ trait ProgressReporter: CallbackReporter {
             Ok((state, trans)) => {
                 if let Err(e) = report(leave_state, None, None, None).await {
                     warn!("report failed: {}", e);
-                };
+                }
                 Ok((state, trans))
             }
             Err(e) => {

--- a/updatehub/src/states/mod.rs
+++ b/updatehub/src/states/mod.rs
@@ -348,6 +348,12 @@ impl State {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// Returns an error when the settings or the runtime settings fail to load,
+/// when the firmware metadata cannot be collected, or when the agent cannot
+/// listen on its socket.
 pub async fn run(settings: &Path) -> crate::Result<()> {
     crate::logger::start_memory_logging();
     let settings = Settings::load(settings)?;

--- a/updatehub/src/states/probe.rs
+++ b/updatehub/src/states/probe.rs
@@ -94,7 +94,7 @@ impl StateChangeImpl for Probe {
         match probe {
             ProbeResponse::NoUpdate => {
                 crate::logger::record_out_of_scope(|| {
-                    info!("no update is current available for this device")
+                    info!("no update is current available for this device");
                 });
 
                 // Store timestamp of last polling
@@ -107,7 +107,7 @@ impl StateChangeImpl for Probe {
 
             ProbeResponse::ExtraPoll(s) => {
                 crate::logger::record_out_of_scope(|| {
-                    info!("delaying the probing for {} seconds as requested by the server", s)
+                    info!("delaying the probing for {} seconds as requested by the server", s);
                 });
                 Ok((State::Probe(self), machine::StepTransition::Delayed(Duration::seconds(s))))
             }

--- a/updatehub/src/states/tests.rs
+++ b/updatehub/src/states/tests.rs
@@ -92,7 +92,7 @@ fn validate_v1_restored_runtime_settings() {
     )
     .unwrap();
     // Overwrite runtimesettings with a v1 model
-    let original_runtime_settings = r#"
+    let original_runtime_settings = r"
 [Polling]
 LastPoll=2021-06-01T14:38:57-03:00
 FirstPoll=2021-05-01T13:33:33-03:00
@@ -102,7 +102,7 @@ ProbeASAP=false
 
 [Update]
 UpgradeToInstallation=0
-"#;
+";
     std::fs::write(&setup.runtime_settings.stored_path, original_runtime_settings).unwrap();
     let mut loaded_runtime_settings =
         RuntimeSettings::load(&setup.runtime_settings.stored_path).unwrap();

--- a/updatehub/src/states/validation.rs
+++ b/updatehub/src/states/validation.rs
@@ -33,16 +33,13 @@ impl StateChangeImpl for Validation {
 
     async fn handle(self, context: &mut Context) -> Result<(State, machine::StepTransition)> {
         if let Some(key) = context.firmware.pub_key.as_ref() {
-            match self.sign.as_ref() {
-                Some(sign) => {
-                    debug!("validating signature");
-                    sign.validate(key, &self.package)
-                        .log_error_msg("uhupkg failed signature validation")?;
-                }
-                None => {
-                    error!("missing signature key");
-                    return Err(super::TransitionError::SignatureNotFound);
-                }
+            if let Some(sign) = self.sign.as_ref() {
+                debug!("validating signature");
+                sign.validate(key, &self.package)
+                    .log_error_msg("uhupkg failed signature validation")?;
+            } else {
+                error!("missing signature key");
+                return Err(super::TransitionError::SignatureNotFound);
             }
         } else {
             info!("no signature key available on device, ignoring signature validation");
@@ -70,7 +67,7 @@ impl StateChangeImpl for Validation {
         self.package
             .validate_install_modes(&context.settings, inactive_installation_set)
             .log_error_msg("install mode failed validation")?;
-        for obj in self.package.objects(inactive_installation_set).iter() {
+        for obj in self.package.objects(inactive_installation_set) {
             if let Err(e) = obj.check_requirements(&object_context).await {
                 error!(
                     "update package: {} ({}) has failed to meet the install requirements",
@@ -87,8 +84,7 @@ impl StateChangeImpl for Validation {
         if context
             .runtime_settings
             .applied_package_uid()
-            .map(|u| *u == update_package.package_uid())
-            .unwrap_or_default()
+            .is_some_and(|u| *u == update_package.package_uid())
         {
             info!("not downloading update package, the same package has already been installed");
             Ok((State::EntryPoint(EntryPoint {}), machine::StepTransition::Immediate))
@@ -115,10 +111,10 @@ impl StateChangeImpl for Validation {
                     for object in not_ready {
                         match object {
                             (filename, Ok(status)) => {
-                                error!(" file '{}' is {:?}", filename, status)
+                                error!(" file '{}' is {:?}", filename, status);
                             }
                             (filename, Err(err)) => {
-                                error!(" file '{}' has failed with error: {:?}", filename, err)
+                                error!(" file '{}' has failed with error: {:?}", filename, err);
                             }
                         }
                     }

--- a/updatehub/src/tests.rs
+++ b/updatehub/src/tests.rs
@@ -192,7 +192,7 @@ impl TestEnvironmentBuilder {
             fs::remove_file(&file_path).unwrap();
 
             let mut runtime_settings = RuntimeSettings::default();
-            runtime_settings.path = file_path.clone();
+            runtime_settings.path.clone_from(&file_path);
             if self.booting_from_update {
                 runtime_settings.enable_persistency();
                 runtime_settings.set_upgrading_to(Set(InstallationSet::A)).unwrap();

--- a/updatehub/src/tests.rs
+++ b/updatehub/src/tests.rs
@@ -126,10 +126,7 @@ impl TestEnvironmentBuilder {
                 hardware_hook(dir_path),
                 &format!(
                     "#!/bin/sh\necho {}",
-                    match self.invalid_hardware {
-                        false => "board",
-                        true => "invalid",
-                    }
+                    if self.invalid_hardware { "invalid" } else { "board" }
                 ),
             );
             create_hook(
@@ -166,7 +163,7 @@ impl TestEnvironmentBuilder {
                 create_hook(validate_hook(&firmware.stored_path), &script);
             }
 
-            for bin in self.extra_binaries.into_iter() {
+            for bin in self.extra_binaries {
                 let mut file = fs::File::create(bin_dir_path.join(&bin)).unwrap();
                 writeln!(file, "#!/bin/sh\necho {} $@ >> {}", bin, output_file.to_string_lossy())
                     .unwrap();

--- a/updatehub/src/update_package/mod.rs
+++ b/updatehub/src/update_package/mod.rs
@@ -70,7 +70,7 @@ impl UpdatePackageExt for UpdatePackage {
         if let Some(mode) = self
             .objects(installation_set)
             .iter()
-            .map(|o| o.mode())
+            .map(super::object::info::Info::mode)
             .find(|mode| !install_modes.contains(mode))
         {
             return Err(Error::IncompatibleInstallMode(mode));
@@ -104,7 +104,7 @@ impl UpdatePackageExt for UpdatePackage {
             .filter(|o| {
                 o.status(&settings.update.download_dir)
                     .map_err(|e| {
-                        error!("fail accessing the object: {} (err: {})", o.sha256sum(), e)
+                        error!("fail accessing the object: {} (err: {})", o.sha256sum(), e);
                     })
                     .unwrap_or(object::info::Status::Missing)
                     .eq(&filter)

--- a/updatehub/src/utils/definitions.rs
+++ b/updatehub/src/utils/definitions.rs
@@ -28,11 +28,11 @@ impl Access {
     }
 }
 
-/// Utility functions for [TargetType](pkg_schema::definitions::TargetType)
+/// Utility functions for [`TargetType`](pkg_schema::definitions::TargetType)
 pub(crate) trait TargetTypeExt {
     /// Checks whether the device is valid to start installation, i.e.,
     /// device exists, use have write permission, and is free of mounted
-    /// filesystems when the handler asks for [Access::Exclusive].
+    /// filesystems when the handler asks for [`Access::Exclusive`].
     fn valid(&self, access: Access) -> Result<&Self>;
 
     /// Gets device's path for mounting.

--- a/updatehub/src/utils/fs.rs
+++ b/updatehub/src/utils/fs.rs
@@ -140,7 +140,7 @@ fn parse_mount_entry(line: &str) -> Option<MountEntry> {
 
     Some(MountEntry {
         device: (major.parse().ok()?, minor.parse().ok()?),
-        source: fields.get(separator + 2)?.to_string(),
+        source: (*fields.get(separator + 2)?).to_string(),
         mount_point: PathBuf::from(fields.get(4)?),
     })
 }
@@ -206,9 +206,10 @@ pub(crate) fn is_executable_in_path(cmd: &str) -> Result<()> {
 
     #[cfg(test)]
     if let Some(dirs) = search_path::current() {
-        return match dirs.iter().any(|dir| is_executable_file(&dir.join(cmd))) {
-            true => Ok(()),
-            false => Err(Error::ExecutableNotInPath(cmd.to_owned())),
+        return if dirs.iter().any(|dir| is_executable_file(&dir.join(cmd))) {
+            Ok(())
+        } else {
+            Err(Error::ExecutableNotInPath(cmd.to_owned()))
         };
     }
 
@@ -273,18 +274,18 @@ pub(crate) mod search_path {
     }
 
     pub(super) fn current() -> Option<Vec<PathBuf>> {
-        OVERRIDE.with_borrow(|o| o.clone())
+        OVERRIDE.with_borrow(std::clone::Clone::clone)
     }
 }
 
-pub(crate) fn format(target: &Path, fs: Filesystem, options: &Option<String>) -> Result<()> {
+pub(crate) fn format(target: &Path, fs: Filesystem, options: Option<&str>) -> Result<()> {
     // The commands below are forced so they run unattended, which also means
     // they will not refuse to wipe a mounted filesystem on their own.
     ensure_not_mounted(target)?;
 
     trace!("formating {:?} as {}", target, fs);
     let target = target.display();
-    let options = options.clone().unwrap_or_default();
+    let options = options.unwrap_or_default();
 
     let cmd = match fs {
         Filesystem::Jffs2 => format!("flash_erase -j {options} {target} 0 0"),
@@ -330,12 +331,12 @@ pub(crate) fn chmod(path: &Path, mode: u32) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn chown(path: &Path, uid: &Option<Uid>, gid: &Option<Gid>) -> Result<()> {
+pub(crate) fn chown(path: &Path, uid: Option<&Uid>, gid: Option<&Gid>) -> Result<()> {
     trace!("applying ownership of uid:{:?} and gid:{:?} to {:?}", uid, gid, path);
     Ok(nix::unistd::chown(
         path,
-        uid.as_ref().map(|id| nix::unistd::Uid::from_raw(id.as_u32())),
-        gid.as_ref().map(|id| nix::unistd::Gid::from_raw(id.as_u32())),
+        uid.map(|id| nix::unistd::Uid::from_raw(id.as_u32())),
+        gid.map(|id| nix::unistd::Gid::from_raw(id.as_u32())),
     )?)
 }
 
@@ -537,7 +538,7 @@ mod tests {
             "an unmounted loop device should be free to install onto"
         );
 
-        format(&loop_device.device, Filesystem::Ext4, &None).unwrap();
+        format(&loop_device.device, Filesystem::Ext4, None).unwrap();
         let guard = mount(&loop_device.device, Filesystem::Ext4, "").unwrap();
 
         let in_use = ensure_not_mounted(&loop_device.device);

--- a/updatehub/src/utils/fs.rs
+++ b/updatehub/src/utils/fs.rs
@@ -469,9 +469,8 @@ mod tests {
         ));
     }
 
-    // Requires root, as creating a loop device does.
     #[test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     fn device_nodes_are_measured_by_their_own_capacity() {
         let loop_device = FakeLoopDevice::new(LOOP_DEVICE_SIZE).unwrap();
 
@@ -527,9 +526,8 @@ mod tests {
         assert!(ensure_not_mounted(Path::new("/dev/updatehub-inexistent-device")).is_ok());
     }
 
-    // Requires root, as creating a loop device does.
     #[test]
-    #[ignore]
+    #[ignore = "needs root to attach a loop device"]
     fn mounted_device_is_in_use() {
         let loop_device = FakeLoopDevice::new(LOOP_DEVICE_SIZE).unwrap();
 

--- a/updatehub/src/utils/mtd.rs
+++ b/updatehub/src/utils/mtd.rs
@@ -173,9 +173,8 @@ mod ffi {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use lazy_static::lazy_static;
     use pretty_assertions::assert_eq;
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, LazyLock, Mutex};
 
     pub(crate) struct FakeUbi {
         #[allow(dead_code)]
@@ -265,9 +264,7 @@ pub(crate) mod tests {
     }
 
     // Used to serialize access to MTD devices
-    lazy_static! {
-        pub static ref SERIALIZE: Arc<Mutex<()>> = Arc::new(Mutex::default());
-    }
+    pub static SERIALIZE: LazyLock<Arc<Mutex<()>>> = LazyLock::new(|| Arc::new(Mutex::default()));
 
     #[test]
     #[ignore]

--- a/updatehub/src/utils/mtd.rs
+++ b/updatehub/src/utils/mtd.rs
@@ -16,10 +16,7 @@ pub(crate) fn target_device_from_ubi_volume_name(volume: &str) -> Result<PathBuf
         .min_depth(1)
         .into_iter()
         .filter_entry(|p| {
-            p.file_name()
-                .to_str()
-                .map(|n| n.starts_with("ubi") && !n.contains('_'))
-                .unwrap_or(false)
+            p.file_name().to_str().is_some_and(|n| n.starts_with("ubi") && !n.contains('_'))
         })
         .filter_map(std::result::Result::ok)
         .find_map(|entry| {

--- a/updatehub/src/utils/mtd.rs
+++ b/updatehub/src/utils/mtd.rs
@@ -264,7 +264,7 @@ pub(crate) mod tests {
     pub static SERIALIZE: LazyLock<Arc<Mutex<()>>> = LazyLock::new(|| Arc::new(Mutex::default()));
 
     #[test]
-    #[ignore]
+    #[ignore = "needs root to load the MTD simulator modules"]
     fn device_from_mtd_name() {
         let _lock = SERIALIZE.lock();
         let dev_names = vec!["system0", "system1"];
@@ -283,7 +283,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "needs root to load the MTD simulator modules"]
     fn test_is_nand() {
         let _lock = SERIALIZE.lock();
 
@@ -298,7 +298,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "needs root to load the MTD simulator modules"]
     fn device_from_ubi_volume_name() {
         let _lock = SERIALIZE.lock();
         let volume_names = vec!["some_ui_volume", "another_ubi_volume"];
@@ -315,7 +315,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "needs root to load the MTD simulator modules"]
     fn device_from_ubi_volume_name_multiple_volumes() {
         let _lock = SERIALIZE.lock();
         let volume_names = vec![

--- a/updatehub/src/utils/test_env.rs
+++ b/updatehub/src/utils/test_env.rs
@@ -6,17 +6,14 @@
 //! only needs `is_executable_in_path` to see other directories. It changes no
 //! process state at all.
 
-use lazy_static::lazy_static;
 use std::{
     env,
     ffi::OsString,
     path::Path,
-    sync::{Mutex, MutexGuard},
+    sync::{LazyLock, Mutex, MutexGuard},
 };
 
-lazy_static! {
-    static ref ENV_LOCK: Mutex<()> = Mutex::default();
-}
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(Mutex::default);
 
 /// Holds `PATH` at a test-defined value, and restores it on drop.
 ///

--- a/updatehub/src/utils/test_env.rs
+++ b/updatehub/src/utils/test_env.rs
@@ -56,7 +56,7 @@ impl PathEnvGuard {
     fn acquire() -> (MutexGuard<'static, ()>, Option<OsString>) {
         // A panicking test poisons the lock, but `Drop` still restored `PATH`
         // during the unwind, so the poison carries no information.
-        let lock = ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let lock = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let previous = env::var_os("PATH");
 
         (lock, previous)

--- a/updatehub/tests/common.rs
+++ b/updatehub/tests/common.rs
@@ -79,10 +79,10 @@ impl Settings {
             setup = setup.validate_callback(s.to_owned());
         }
         if let Some(l) = self.install_modes {
-            setup = setup.supported_install_modes(l)
+            setup = setup.supported_install_modes(l);
         }
         if !self.polling {
-            setup = setup.disable_polling()
+            setup = setup.disable_polling();
         }
         let mut setup = setup.finish();
 
@@ -380,7 +380,7 @@ pub fn rewrite_log_output(s: String) -> (String, String) {
     let version_re = Regex::new(r"Agent .*").unwrap();
     let tmpfile_re = Regex::new(r#""/.*/.tmp.*""#).unwrap();
     let date_re = Regex::new(r"\b(?:Jan|...|Dec) (\d{2}) (\d{2}):(\d{2}):(\d{2}).(\d{3})").unwrap();
-    let time_re = Regex::new(r#"(\d{5}) seconds"#).unwrap();
+    let time_re = Regex::new(r"(\d{5}) seconds").unwrap();
     let trce_re = Regex::new(r"<timestamp> TRCE.*").unwrap();
     let debg_re = Regex::new(r"<timestamp> DEBG.*").unwrap();
     let download_re = Regex::new(r"DEBG (\d{1,3})%").unwrap();
@@ -390,17 +390,13 @@ pub fn rewrite_log_output(s: String) -> (String, String) {
     let s = tmpfile_re.replace_all(&s, r#""<file>""#);
     let s = date_re.replace_all(&s, "<timestamp>");
     let s = download_re.replace_all(&s, "DEBG <percentage>%");
-    let s = time_re.replace_all(&s, r#"<time>"#);
+    let s = time_re.replace_all(&s, r"<time>");
     let s_trce = s.replace("\r\n", "\n").trim().to_owned();
 
     let s_info = trce_re.replace_all(&s_trce, "");
     let s_info = debg_re.replace_all(&s_info, "");
-    let s_info = s_info
-        .split('\n')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n");
+    let s_info =
+        s_info.split('\n').map(str::trim).filter(|s| !s.is_empty()).collect::<Vec<_>>().join("\n");
 
     (s_trce, s_info)
 }

--- a/updatehub/tests/common.rs
+++ b/updatehub/tests/common.rs
@@ -383,7 +383,7 @@ pub fn rewrite_log_output(s: String) -> (String, String) {
     let time_re = Regex::new(r#"(\d{5}) seconds"#).unwrap();
     let trce_re = Regex::new(r"<timestamp> TRCE.*").unwrap();
     let debg_re = Regex::new(r"<timestamp> DEBG.*").unwrap();
-    let download_re = Regex::new(r"DEBG (\d{2})%").unwrap();
+    let download_re = Regex::new(r"DEBG (\d{1,3})%").unwrap();
 
     let s = server_address_re.replace_all(&s, "http://127.0.0.1:[port]");
     let s = version_re.replace_all(&s, "Agent <version>");

--- a/updatehub/tests/failed_integration_test.rs
+++ b/updatehub/tests/failed_integration_test.rs
@@ -129,8 +129,8 @@ fn failing_invalid_file_config() {
 
     write!(
         file,
-        r#"[network]
-    server_address=https://api.updatehub.io, listen_socket=localhost:8080;"#
+        r"[network]
+    server_address=https://api.updatehub.io, listen_socket=localhost:8080;"
     )
     .unwrap();
 
@@ -393,9 +393,9 @@ fn invalid_server_response() {
 
 #[test]
 fn invalid_statechange_callback() {
-    let state_change_script = r#"#! /bin/sh
+    let state_change_script = r"#! /bin/sh
 exit 1
-"#;
+";
 
     let mut server = mockito::Server::new();
     let (mut session, setup) = Settings::default()

--- a/updatehub/tests/successful_integration_test.rs
+++ b/updatehub/tests/successful_integration_test.rs
@@ -268,7 +268,7 @@ fn correct_config_update_polling() {
     <timestamp> DEBG starting download of: testfile (23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4)
     <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG 100% of the file has been downloaded
+    <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> TRCE starting to handle 'validation' state
     <timestamp> INFO no signature key available on device, ignoring signature validation
     <timestamp> TRCE starting to handle 'install' state
@@ -297,7 +297,7 @@ fn correct_config_update_polling() {
     <timestamp> DEBG starting download of: testfile (23c3c412177bd37b9b61bf4738b18dc1fe003811c2583a14d2d9952d8b6a75b4)
     <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> DEBG <percentage>% of the file has been downloaded
-    <timestamp> DEBG 100% of the file has been downloaded
+    <timestamp> DEBG <percentage>% of the file has been downloaded
     <timestamp> TRCE starting to handle 'validation' state
     <timestamp> INFO no signature key available on device, ignoring signature validation
     <timestamp> TRCE starting to handle 'install' state

--- a/updatehub/tests/successful_integration_test.rs
+++ b/updatehub/tests/successful_integration_test.rs
@@ -569,9 +569,9 @@ fn correct_config_remote_install() {
 
 #[test]
 fn validation_callback() {
-    let validate_script = r#"#! /bin/sh
+    let validate_script = r"#! /bin/sh
 exit 0
-"#;
+";
 
     // Even tho we don't update we start the mock for the probe performed on update
     let mut server = mockito::Server::new();
@@ -644,9 +644,9 @@ exit 0
 
 #[test]
 fn failed_validation_callback() {
-    let validate_script = r#"#! /bin/sh
+    let validate_script = r"#! /bin/sh
 exit 1
-"#;
+";
 
     let (mut session, _setup) = Settings::default()
         .timeout(300)
@@ -657,7 +657,7 @@ exit 1
     let (output_server_trce, output_server_info) = get_output_server(
         &mut session,
         StopMessage::Custom(
-            r#"\r\n.* WARN swapped active installation set and running rollback"#.to_string(),
+            r"\r\n.* WARN swapped active installation set and running rollback".to_string(),
         ),
     );
 
@@ -683,9 +683,9 @@ exit 1
 #[test]
 #[cfg(feature = "v1-parsing")]
 fn v1_validation_callback() {
-    let validate_script = r#"#! /bin/sh
+    let validate_script = r"#! /bin/sh
 exit 0
-"#;
+";
 
     // Even tho we don't update we start the mock for the probe performed on update
     let mut server = mockito::Server::new();
@@ -700,7 +700,7 @@ exit 0
     // Overwrite runtimesettings with a v1 model
     std::fs::write(
         &setup.runtime_settings.stored_path,
-        r#"
+        r"
 [Polling]
 LastPoll=2021-06-01T14:38:57-03:00
 FirstPoll=2021-05-01T13:33:33-03:00
@@ -710,7 +710,7 @@ ProbeASAP=false
 
 [Update]
 UpgradeToInstallation=1
-"#,
+",
     )
     .unwrap();
 
@@ -776,9 +776,9 @@ UpgradeToInstallation=1
 #[test]
 #[cfg(feature = "v1-parsing")]
 fn v1_failed_from_v1_validation_callback() {
-    let validate_script = r#"#! /bin/sh
+    let validate_script = r"#! /bin/sh
 exit 1
-"#;
+";
 
     let (mut session, setup) = Settings::default()
         .timeout(300)
@@ -789,7 +789,7 @@ exit 1
     // Overwrite runtimesettings with a v1 model
     std::fs::write(
         &setup.runtime_settings.stored_path,
-        r#"
+        r"
 [Polling]
 LastPoll=2021-06-01T14:38:57-03:00
 FirstPoll=2021-05-01T13:33:33-03:00
@@ -799,14 +799,14 @@ ProbeASAP=false
 
 [Update]
 UpgradeToInstallation=0
-"#,
+",
     )
     .unwrap();
 
     let (output_server_trce, output_server_info) = get_output_server(
         &mut session,
         StopMessage::Custom(
-            r#"\r\n.* WARN swapped active installation set and running rollback"#.to_string(),
+            r"\r\n.* WARN swapped active installation set and running rollback".to_string(),
         ),
     );
 
@@ -834,9 +834,9 @@ UpgradeToInstallation=0
 #[test]
 #[cfg(feature = "v1-parsing")]
 fn v1_failed_from_v2_validation_callback() {
-    let validate_script = r#"#! /bin/sh
+    let validate_script = r"#! /bin/sh
 exit 1
-"#;
+";
 
     let (mut session, _setup) = Settings::default()
         .timeout(300)
@@ -847,7 +847,7 @@ exit 1
     let (output_server_trce, output_server_info) = get_output_server(
         &mut session,
         StopMessage::Custom(
-            r#"\r\n.* WARN swapped active installation set and running rollback"#.to_string(),
+            r"\r\n.* WARN swapped active installation set and running rollback".to_string(),
         ),
     );
 


### PR DESCRIPTION
`cargo clippy --all-features --all-targets -- -W clippy::pedantic` reported **203 warnings** on
`master`. This branch closes **166** of them across six commits, one concern per commit. The
default clippy run was clean before this branch and stays clean.

One warning turned out to hide a real defect. The rest are readability and documentation.

## The defect

`save_body_to` in the cloud SDK logged the download progress from a `f32` that it grew by one
addition per chunk, then cast back to an integer. The rounding error grew with the number of
chunks, so a download that finished logged `99%`. It now counts bytes in a `u64` and derives the
percentage from the total, which is exact and needs no cast at all.

The change surfaced a second, smaller problem: the integration tests normalized the percentage
with a regular expression that accepted two digits only. It never saw a three digit value before,
so `100%` reached the snapshot as a literal. The expression now accepts one to three digits.

## The commits

| Commit | What it does |
|---|---|
| `fix: cloud-sdk: compute the download progress with integer arithmetic` | The defect above. |
| `refactor: remove the lossy casts and the implicit clones` | Replaces every `as` cast that can truncate or lose the sign with `try_from`, and removes three clones written in a roundabout way. |
| `refactor: replace lazy_static with std::sync::LazyLock` | Four statics move to the standard library type. The `lazy_static` dependency goes away. |
| `style: apply the mechanical clippy::pedantic code fixes` | Semicolons, closures, `if let` over one-armed matches, `Option<&T>` over `&Option<T>`. No change in behavior. |
| `test: state why each ignored test stays out of the default run` | Sixteen `#[ignore]` attributes now say what they need. Two more do not need anything, so they run by default. |
| `docs: document how the public functions fail, and mark the pure ones` | `# Errors` and `# Panics` sections on the public API, `#[must_use]` on the pure accessors, and a `clippy.toml` that knows `UpdateHub` is a name. |

## What stays open, and why

37 warnings remain. Each one asks for a change that would make the code worse, or for work that
does not belong in a cleanup branch.

| Lint | Count | Reason |
|---|---|---|
| `unused_async` | 8 | Trait methods with a default body, the mock cloud client that must match the real client, a warp handler, and a public SDK function. The `async` is part of the contract. |
| `unnecessary_debug_formatting` | 5 | `{:?}` quotes a path. The flash and raw-delta handlers build shell commands, where the quotes are what makes a path with a space safe. |
| `too_many_lines` | 4 | Needs the functions split, which is its own change. |
| `must_use_candidate`, `missing_panics_doc`, `needless_pass_by_value` | 19 | All on test helpers. The attributes and the prose would state what a reader of the test already sees, and passing by value there moves data the caller is done with. |
| `used_underscore_binding` | 1 | The `_mount` field of `MountGuard`. The name states that the guard only holds the mount alive. |
| `wildcard_imports` | 1 | `use super::*` in a test module. |

## How I verified it

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-features --all --tests -- -D clippy::all`
- `cargo check --locked --release --all --bins --examples --tests`, with and without `--all-features`
- `cargo test --locked --all --all-features --no-fail-fast`: 96 unit tests, 13 successful
  integration tests, 7 failed-path integration tests, and the rest of the suite all pass. 16 tests
  stay ignored because they need root.

The tests that need root and MTD hardware simulation were not run. They were already outside the
default run before this branch.
